### PR TITLE
Display tab navigation after user creates initial profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@craftzdog/react-native-buffer": "6.0.5",
     "@decentralized-identity/ion-tools": "1.0.7",
     "@legendapp/state": "1.1.0",
+    "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "6.1.6",
     "@react-navigation/native-stack": "6.9.12",
     "expo": "48.0.17",

--- a/src/features/browser/BrowserScreen.tsx
+++ b/src/features/browser/BrowserScreen.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { SafeAreaView } from "react-native";
+import { WebView } from "react-native-webview";
+
+export const BrowserScreen = () => {
+  function onMessage(data) {
+    alert(data.nativeEvent.data);
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <WebView
+        scalesPageToFit={false}
+        mixedContentMode="compatibility"
+        onMessage={onMessage}
+        source={{
+          html: ` 
+          <html>
+          <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+          </head>
+          <body
+            style="
+              display: flex;
+              justify-content: center;
+              flex-direction: column;
+              align-items: center;
+            "
+          >
+            <button
+            onclick="sendDataToReactNativeApp()"
+              style="
+                padding: 20;
+                width: 200;
+                font-size: 20;
+                color: white;
+                background-color: #6751ff;
+              "
+            >
+              Send Data To React Native App
+            </button>
+            <script>
+              const sendDataToReactNativeApp = async () => {
+                window.ReactNativeWebView.postMessage('Data from WebView / Website');
+              };
+            </script>
+          </body>
+        </html>        
+`,
+        }}
+      />
+    </SafeAreaView>
+  );
+};

--- a/src/features/profile/CreateProfileScreen.tsx
+++ b/src/features/profile/CreateProfileScreen.tsx
@@ -24,7 +24,7 @@ export const CreateProfileScreen = ({ navigation, route }) => {
     if (navigation.canGoBack()) {
       navigation.goBack();
     } else {
-      navigation.replace("ProfilesScreen");
+      navigation.replace("Home");
     }
   };
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,50 +3,39 @@ import {
   type NativeStackNavigationOptions,
   createNativeStackNavigator,
 } from "@react-navigation/native-stack";
-import { CredentialScreen } from "../features/credentials/CredentialScreen";
 import { profilesAtom } from "../features/profile/atoms";
-import { ProfilesScreen } from "../features/profile/ProfileScreen";
 import { CreateProfileScreen } from "../features/profile/CreateProfileScreen";
+import { TabNavigator } from "./TabNavigator";
 
 const Stack = createNativeStackNavigator();
 
 export const AppNavigator = () => {
   const getInitialRouteName = () =>
-    profilesAtom.peek().length ? "ProfilesScreen" : "CreateProfileScreen";
+    profilesAtom.peek().length ? "Home" : "CreateProfileScreen";
 
   return (
-    <Stack.Navigator initialRouteName={getInitialRouteName()}>
+    <Stack.Navigator
+      initialRouteName={getInitialRouteName()}
+      screenOptions={StackNavigatorOptions}
+    >
       <Stack.Screen
         name="CreateProfileScreen"
         component={CreateProfileScreen}
         options={CreateProfileScreenOptions}
       />
-      <Stack.Screen
-        name="ProfilesScreen"
-        component={ProfilesScreen}
-        options={ProfilesScreenOptions}
-      />
-      <Stack.Screen
-        name="CredentialScreen"
-        component={CredentialScreen}
-        options={CredentialScreenOptions}
-      />
+
+      <Stack.Screen name="Home" component={TabNavigator} />
     </Stack.Navigator>
   );
 };
 
+const StackNavigatorOptions: NativeStackNavigationOptions = {
+  headerShown: false,
+};
+
 const CreateProfileScreenOptions: NativeStackNavigationOptions = {
   title: "Create Profile",
+  headerShown: true,
   headerLargeTitle: true,
   animation: "slide_from_bottom",
-};
-
-const ProfilesScreenOptions: NativeStackNavigationOptions = {
-  title: "Profiles",
-  headerLargeTitle: true,
-};
-
-const CredentialScreenOptions: NativeStackNavigationOptions = {
-  title: "Get Credentials",
-  headerLargeTitle: true,
 };

--- a/src/navigation/SsiStackNavigator.tsx
+++ b/src/navigation/SsiStackNavigator.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  NativeStackNavigationOptions,
+  createNativeStackNavigator,
+} from "@react-navigation/native-stack";
+import { ProfilesScreen } from "../features/profile/ProfileScreen";
+import { CredentialScreen } from "../features/credentials/CredentialScreen";
+import { CreateProfileScreen } from "../features/profile/CreateProfileScreen";
+
+const Stack = createNativeStackNavigator();
+
+export const SsiStackNavigator = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="ProfilesScreen"
+        component={ProfilesScreen}
+        options={ProfilesScreenOptions}
+      />
+      <Stack.Screen
+        name="CredentialScreen"
+        component={CredentialScreen}
+        options={CredentialScreenOptions}
+      />
+      <Stack.Screen
+        name="CreateProfileScreen"
+        component={CreateProfileScreen}
+        options={CreateProfileScreenOptions}
+      />
+    </Stack.Navigator>
+  );
+};
+
+const ProfilesScreenOptions: NativeStackNavigationOptions = {
+  title: "Profiles",
+  headerLargeTitle: true,
+};
+
+const CredentialScreenOptions: NativeStackNavigationOptions = {
+  title: "Get Credentials",
+  headerLargeTitle: true,
+};
+
+const CreateProfileScreenOptions: NativeStackNavigationOptions = {
+  title: "Create Profile",
+  headerShown: true,
+  headerLargeTitle: true,
+};

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import {
+  BottomTabNavigationOptions,
+  createBottomTabNavigator,
+} from "@react-navigation/bottom-tabs";
+import { SsiStackNavigator } from "./SsiStackNavigator";
+import { BrowserScreen } from "../features/browser/BrowserScreen";
+
+const Tab = createBottomTabNavigator();
+
+export const TabNavigator = () => {
+  return (
+    <Tab.Navigator screenOptions={TabNavigatorOptions}>
+      <Tab.Screen name="SSI" component={SsiStackNavigator} />
+      <Tab.Screen name="Browser" component={BrowserScreen} />
+    </Tab.Navigator>
+  );
+};
+
+const TabNavigatorOptions: BottomTabNavigationOptions = {
+  headerShown: false,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,6 +2300,15 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@react-navigation/bottom-tabs@^6.5.7":
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.7.tgz#08470c96e0d11481422214bb98f0ff034038856c"
+  integrity sha512-9oZYyRu2z7+1pr2dX5V54rHFPmlj4ztwQxFe85zwpnGcPtGIsXj7VCIdlHnjRHJBBFCszvJGQpYY6/G2+DfD+A==
+  dependencies:
+    "@react-navigation/elements" "^1.3.17"
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@react-navigation/core@^6.4.8":
   version "6.4.8"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.8.tgz#a18e106d3c59cdcfc4ce53f7344e219ed35c88ed"
@@ -3484,7 +3493,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.3, color-string@^1.6.0:
+color-string@^1.5.3, color-string@^1.6.0, color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
@@ -3499,6 +3508,14 @@ color@^3.1.2:
   dependencies:
     color-convert "^1.9.3"
     color-string "^1.6.0"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^1.0.7:
   version "1.4.0"


### PR DESCRIPTION
There are two tabs the user can switch between after creating their initial profile:

1. SSI - This tab houses everything SSI related (DID, VCs, etc.)
2. Browser - In-App browser that can send messages to/from React Native. This isn't set in stone by any means, just a means of exploration as to how an in-app browser experience may work (similar to Metamask).

| SSI Tab | Browser Tab |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-24 at 13 01 28](https://github.com/tbdeng/wallet/assets/88001738/3cd0eb95-9747-4343-b065-d3eb19d0bf38) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-24 at 13 01 30](https://github.com/tbdeng/wallet/assets/88001738/1a0f47dc-64a7-4c88-bfd1-4150f3efc497) |

https://app.asana.com/0/1204262598677300/1204639505738278/f
