### PR TITLE
Use Web5.did.create(key) for profile instead of verite

### DIFF
--- a/src/features/credentials/CredentialScreen.tsx
+++ b/src/features/credentials/CredentialScreen.tsx
@@ -51,7 +51,7 @@ export const CredentialScreen = ({ route }) => {
       <View style={styles.pageContainer}>
         <Text variant="titleMedium">
           Welcome, {navigatedProfile?.name?.peek() + "\n\n"}
-          Your DID ION is: {navigatedProfile?.didIon?.peek() + "\n\n"}
+          Your DID ION is: {navigatedProfile?.didIon?.id.peek() + "\n\n"}
           Your DID Key is: {navigatedProfile?.didKey?.id.peek() + "\n\n"}
         </Text>
         <For optimized each={navigatedProfile?.credentials}>

--- a/src/features/mock-issuer/utils.ts
+++ b/src/features/mock-issuer/utils.ts
@@ -11,6 +11,7 @@ import {
   W3CCredential,
   buildKycAmlManifest,
 } from "verite";
+import { DidState } from "@tbd54566975/dids";
 
 const issuerDidKey = randomDidKey(crypto.randomBytes);
 
@@ -77,7 +78,7 @@ const mockManifest = buildKycAmlManifest({
 
 // get credentials without application flow
 const issueCredentials = async (
-  applicantDidKey: DidKey
+  applicantDid: DidState
 ): Promise<Verifiable<W3CCredential>> => {
   const mockIssuer = buildIssuer(issuerDidKey.id, issuerDidKey.privateKey);
 
@@ -93,7 +94,7 @@ const issueCredentials = async (
   // Generate the signed, encoded credential
   const encoded = await buildAndSignVerifiableCredential(
     mockIssuer,
-    applicantDidKey,
+    applicantDid.id,
     mockAttestation,
     mockAttestationType
   );

--- a/src/features/profile/CreateProfileScreen.tsx
+++ b/src/features/profile/CreateProfileScreen.tsx
@@ -1,17 +1,16 @@
 import React, { useState } from "react";
 import { StyleSheet, ScrollView, View } from "react-native";
-import crypto from "crypto";
 import { Text, Button, TextInput } from "react-native-paper";
-import { randomDidKey } from "verite";
 import { profilesAtom } from "./atoms";
 import { Web5 } from "@tbd54566975/web5";
+import { DidState } from "@tbd54566975/dids";
 
 export const CreateProfileScreen = ({ navigation, route }) => {
   const [name, setName] = useState("");
 
   const onPressCreateProfile = async () => {
     const didIon = await createDidIon();
-    const didKey = createDidKey();
+    const didKey = await createDidKey();
 
     profilesAtom.push({
       id: didKey.id,
@@ -28,14 +27,12 @@ export const CreateProfileScreen = ({ navigation, route }) => {
     }
   };
 
-  const createDidIon = async () => {
-    const didState = await Web5.did.create("ion");
-    return didState.id;
+  const createDidIon = async (): Promise<DidState> => {
+    return await Web5.did.create("ion");
   };
 
-  const createDidKey = () => {
-    const didKey = randomDidKey(crypto.randomBytes);
-    return didKey;
+  const createDidKey = async (): Promise<DidState> => {
+    return await Web5.did.create("key");
   };
 
   return (

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,11 +1,12 @@
-import type { DidKey, Verifiable, W3CCredential } from "verite";
+import { DidState } from "@tbd54566975/dids";
+import type { Verifiable, W3CCredential } from "verite";
 
 export type Credential = Verifiable<W3CCredential> & { id: string };
 
 export type Profile = {
   id: string;
-  didKey: DidKey;
-  didIon: string;
+  didKey: DidState;
+  didIon: DidState;
   name: string;
   credentials: Credential[];
 };


### PR DESCRIPTION
Remove instances of verite's `randomDidKey` and `DidKey` from Profile. 
Replace them with `Web5.did.create("key")` and `DidState` objects.