### PR TITLE
Use Profile from web5-user-agent, implement ProfileManager instance

### DIFF
--- a/src/features/credentials/CredentialScreen.tsx
+++ b/src/features/credentials/CredentialScreen.tsx
@@ -15,11 +15,11 @@ export const CredentialScreen = ({ route }) => {
   }, []);
 
   const onPressGetCredentials = async () => {
-    const didKey = navigatedProfile?.didKey.peek();
+    const did = navigatedProfile?.did.peek();
 
-    if (didKey) {
+    if (did) {
       // create the mock credential
-      const issuedCredentials = await MockIssuerUtils.issueCredentials(didKey);
+      const issuedCredentials = await MockIssuerUtils.issueCredentials(did);
 
       // assign a random uuid for the credential because verite isnt doing it
       const normalizedCredential = {
@@ -51,8 +51,7 @@ export const CredentialScreen = ({ route }) => {
       <View style={styles.pageContainer}>
         <Text variant="titleMedium">
           Welcome, {navigatedProfile?.name?.peek() + "\n\n"}
-          Your DID ION is: {navigatedProfile?.didIon?.id.peek() + "\n\n"}
-          Your DID Key is: {navigatedProfile?.didKey?.id.peek() + "\n\n"}
+          Your DID is: {navigatedProfile?.did?.id.peek() + "\n\n"}
         </Text>
         <For optimized each={navigatedProfile?.credentials}>
           {(cred) => {

--- a/src/features/profile/CreateProfileScreen.tsx
+++ b/src/features/profile/CreateProfileScreen.tsx
@@ -1,23 +1,15 @@
 import React, { useState } from "react";
 import { StyleSheet, ScrollView, View } from "react-native";
 import { Text, Button, TextInput } from "react-native-paper";
-import { profilesAtom } from "./atoms";
-import { Web5 } from "@tbd54566975/web5";
-import { DidState } from "@tbd54566975/dids";
+import ProfileApi from "./ProfileApi";
 
 export const CreateProfileScreen = ({ navigation, route }) => {
   const [name, setName] = useState("");
 
   const onPressCreateProfile = async () => {
-    const didIon = await createDidIon();
-    const didKey = await createDidKey();
-
-    profilesAtom.push({
-      id: didKey.id,
-      didIon,
-      didKey,
-      name,
-      credentials: [],
+    ProfileApi.createProfile({
+      name: name,
+      didMethod: "ion",
     });
 
     if (navigation.canGoBack()) {
@@ -25,14 +17,6 @@ export const CreateProfileScreen = ({ navigation, route }) => {
     } else {
       navigation.replace("Home");
     }
-  };
-
-  const createDidIon = async (): Promise<DidState> => {
-    return await Web5.did.create("ion");
-  };
-
-  const createDidKey = async (): Promise<DidState> => {
-    return await Web5.did.create("key");
   };
 
   return (

--- a/src/features/profile/ProfileApi.ts
+++ b/src/features/profile/ProfileApi.ts
@@ -1,0 +1,56 @@
+import {
+  CreateProfileOptions,
+  ProfileManager,
+} from "@tbd54566975/web5-user-agent";
+import { DidState } from "@tbd54566975/dids";
+import { Web5 } from "@tbd54566975/web5";
+import { Profile } from "../../types/models";
+import { profilesAtom } from "./atoms";
+
+export default new (class implements ProfileManager {
+  async createProfile(options: CreateProfileOptions): Promise<Profile> {
+    if (!options.did && !options.didMethod) {
+      throw new Error("must provide did or didMethod");
+    }
+
+    var did: DidState;
+    if (options.did) {
+      did = options.did;
+    } else {
+      switch (options.didMethod) {
+        case "ion":
+          did = await Web5.did.create("ion");
+          break;
+        case "key":
+          did = await Web5.did.create("key");
+          break;
+        default:
+          throw new Error("Invalid didMethod");
+          break;
+      }
+    }
+
+    const profile: Profile = {
+      id: did.id,
+      did: did,
+      name: options.name ?? "",
+      icon: options.icon ?? "",
+      connections: [],
+      dateCreated: new Date(),
+      credentials: [],
+    };
+
+    profilesAtom.push(profile);
+    return profile;
+  }
+
+  getProfile(id: string): Promise<Profile | undefined> {
+    return Promise.resolve(
+      profilesAtom.find((profile) => profile.id.peek() === id)?.get()
+    );
+  }
+
+  listProfiles(): Promise<Profile[]> {
+    return Promise.resolve(profilesAtom.get());
+  }
+})();

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,13 +1,9 @@
-import { DidState } from "@tbd54566975/dids";
+import { Profile as Web5Profile } from "@tbd54566975/web5-user-agent";
 import type { Verifiable, W3CCredential } from "verite";
 
 export type Credential = Verifiable<W3CCredential> & { id: string };
 
-export type Profile = {
-  id: string;
-  didKey: DidState;
-  didIon: DidState;
-  name: string;
+export type Profile = Web5Profile & {
   credentials: Credential[];
 };
 


### PR DESCRIPTION
Changes the wallet's Profile to extend the `Profile` defined in `@tbd5456679/web5-user-agent`. 

In addition, provides an implementation of the `ProfileManager` interface, which can be used to create new profiles.