### PR TITLE
Add unique icons for the profiles created from the welcome screen

### DIFF
--- a/src/features/onboarding/WelcomeScreen.tsx
+++ b/src/features/onboarding/WelcomeScreen.tsx
@@ -9,9 +9,21 @@ export const WelcomeScreen = ({ navigation }) => {
   };
 
   const onPressStartFresh = () => {
-    ProfileManager.createProfile({ name: "Personal", didMethod: "ion" });
-    ProfileManager.createProfile({ name: "Social", didMethod: "ion" });
-    ProfileManager.createProfile({ name: "Career", didMethod: "ion" });
+    ProfileManager.createProfile({
+      name: "Personal",
+      icon: "account-circle-outline",
+      didMethod: "ion",
+    });
+    ProfileManager.createProfile({
+      name: "Social",
+      icon: "pound",
+      didMethod: "ion",
+    });
+    ProfileManager.createProfile({
+      name: "Career",
+      icon: "briefcase-outline",
+      didMethod: "ion",
+    });
 
     navigation.replace("Home");
   };

--- a/src/features/profile/CreateProfileScreen.tsx
+++ b/src/features/profile/CreateProfileScreen.tsx
@@ -7,7 +7,11 @@ export const CreateProfileScreen = ({ navigation, route }) => {
   const [name, setName] = useState("");
 
   const onPressCreateProfile = async () => {
-    ProfileManager.createProfile({ name: name, didMethod: "ion" });
+    ProfileManager.createProfile({
+      name: name,
+      icon: "account-circle-outline",
+      didMethod: "ion",
+    });
 
     if (navigation.canGoBack()) {
       navigation.goBack();

--- a/src/features/profile/ProfileScreen.tsx
+++ b/src/features/profile/ProfileScreen.tsx
@@ -21,22 +21,27 @@ export const ProfilesScreen = ({ navigation }) => {
           Each profile contains your credentials
         </Text>
         <For each={profilesAtom}>
-          {(profile) => (
-            <List.Item
-              title={`Name: ${profile?.get()?.name}`}
-              description={`Credentials stored: ${
-                profile?.get()?.credentials.length
-              }`}
-              left={(props) => (
-                <List.Icon {...props} icon="account-circle-outline" />
-              )}
-              onPress={() => {
-                navigation.navigate("CredentialScreen", {
-                  name: profile?.get()?.name,
-                });
-              }}
-            />
-          )}
+          {(profile) => {
+            const profileData = profile?.get();
+            if (!profileData) {
+              return <></>;
+            }
+
+            return (
+              <List.Item
+                title={profileData.name}
+                description={`Credentials stored: ${profileData.credentials.length}`}
+                left={(props) => (
+                  <List.Icon {...props} icon={profileData.icon} />
+                )}
+                onPress={() => {
+                  navigation.navigate("CredentialScreen", {
+                    name: profileData.name,
+                  });
+                }}
+              />
+            );
+          }}
         </For>
         <Button mode="contained" onPress={onPressCreateMoreProfiles}>
           Create Another Profile


### PR DESCRIPTION
Displays icons that are associated with the profile. For the default profiles that are created in the "Fresh Start" flow, each will get their own unique icon. Any profile created afterwards will get the `account-circle-outline` icon. We can change this in the future to allow the user to select an icon!

Currently, we can select from [these icons](https://callstack.github.io/react-native-paper/docs/guides/icons/#:~:text=See%20the%20list%20of%20supported%20icons) with a simple string.

Screenshot:

![Simulator Screenshot - iPhone 14 Pro - 2023-06-23 at 09 11 39](https://github.com/tbdeng/wallet/assets/88001738/646cbcab-e4fc-4bf1-b114-e4e88a254af8)

