### PR TITLE
Integrate @web5/identity-agent to create identity on app launch

### DIFF
--- a/blob-polyfill.ts
+++ b/blob-polyfill.ts
@@ -22,6 +22,7 @@ function monkeyPatchBlobConstructor() {
 
       if (blobParts) {
         for (const [index, element] of blobParts.entries()) {
+          // TODO #64: Investigate performance here, and see if we can make an upstream change to fix.
           if (element instanceof Uint8Array) {
             blobParts[index] = decoder.decode(element);
           }
@@ -33,7 +34,7 @@ function monkeyPatchBlobConstructor() {
   };
 
   const blobProxy = new Proxy(OriginalBlob, blobProxyHandler);
-  (global as any).Blob = blobProxy;
+  global.Blob = blobProxy;
 }
 
 /**
@@ -88,8 +89,7 @@ async function getArrayBuffer(blob: Blob): Promise<Uint8Array> {
   }
 }
 
-// eslint-disable-next-line require-await
-async function sleep(ms: number) {
+function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/blob-polyfill.ts
+++ b/blob-polyfill.ts
@@ -73,8 +73,12 @@ function polyfillBlobStream() {
  * until it is ultimately available via the JSI.
  */
 async function getArrayBuffer(blob: Blob): Promise<Uint8Array> {
-  const arrayBuffer = getArrayBufferForBlob(blob);
-  if (arrayBuffer.length === blob.size) {
+  let arrayBuffer: Uint8Array | undefined = undefined;
+  try {
+    arrayBuffer = getArrayBufferForBlob(blob);
+  } catch {}
+
+  if (arrayBuffer && arrayBuffer.length === blob.size) {
     return arrayBuffer;
   } else {
     // The buffer isn't available yet from the JSI.

--- a/blob-polyfill.ts
+++ b/blob-polyfill.ts
@@ -1,0 +1,95 @@
+import { getArrayBufferForBlob } from "react-native-blob-jsi-helper";
+import { ReadableStream } from "web-streams-polyfill";
+
+const decoder = new TextDecoder();
+
+/**
+ * React Native's Blob implementation has a constructor that currently only supports
+ * constructing from parts that are of type: Array<Blob | String>.
+ *
+ * Web5 packages need to be able to construct a Blob where one of the parts is of type `Uint8Array`.
+ *
+ * This function updates the constructor of Blob to convert any parts that are of type `Uint8Array`
+ * into a `string`, so that it can properly work with React Native's Blob implementation.
+ */
+function monkeyPatchBlobConstructor() {
+  const OriginalBlob = global.Blob;
+
+  const blobProxyHandler = {
+    construct(target: any, argumentsList: any) {
+      const blobParts = argumentsList[0];
+      const options = argumentsList[1];
+
+      if (blobParts) {
+        for (const [index, element] of blobParts.entries()) {
+          if (element instanceof Uint8Array) {
+            blobParts[index] = decoder.decode(element);
+          }
+        }
+      }
+
+      return new target(blobParts, options);
+    },
+  };
+
+  const blobProxy = new Proxy(OriginalBlob, blobProxyHandler);
+  (global as any).Blob = blobProxy;
+}
+
+/**
+ * React Native's Blob implementation currently does provide a `stream()` function.
+ *
+ * Web5 packages depend on this function for a multitude of functionality.
+ *
+ * This function provides a polyfill for this function if it does not exist.
+ */
+function polyfillBlobStream() {
+  if (typeof Blob !== "undefined") {
+    if (!Blob.prototype.stream) {
+      Blob.prototype.stream = function (): ReadableStream<Uint8Array> {
+        const blob = this;
+
+        return new ReadableStream({
+          async start(controller) {
+            const arrayBuffer = await getArrayBuffer(blob);
+            controller.enqueue(arrayBuffer);
+            controller.close();
+          },
+        });
+      };
+    }
+  }
+}
+
+/**
+ * Web5 will often create a Blob, then immediately use the Blob's `stream()`
+ * to stream the data for various purposes.
+ *
+ * In React Native, Blobs are created via NativeBlobModule. Despite the API to
+ * create Blobs being synchronous, the actual bytes backing the Blob may not be
+ * available immmediately.
+ *
+ * This function looks for the backing arrayBuffer for a Blob, with small microsleeps
+ * until it is ultimately available via the JSI.
+ */
+async function getArrayBuffer(blob: Blob): Promise<Uint8Array> {
+  const arrayBuffer = getArrayBufferForBlob(blob);
+  if (arrayBuffer.length === blob.size) {
+    return arrayBuffer;
+  } else {
+    // The buffer isn't available yet from the JSI.
+    // Microsleep to advance to the next runloop, and try again.
+    await sleep(1);
+    return getArrayBuffer(blob);
+  }
+}
+
+// eslint-disable-next-line require-await
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function polyfillBlob() {
+  monkeyPatchBlobConstructor();
+  polyfillBlobStream();
+}

--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ import { registerRootComponent } from "expo";
 import { polyfillBlob } from "./blob-polyfill";
 
 if (!global.structuredClone) {
-  var structuredClone = require("realistic-structured-clone");
-  global.structuredClone = structuredClone;
+  global.structuredClone = require("realistic-structured-clone");
 }
 
 polyfillBlob();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
 import "@tbd54566975/web5-react-native-polyfills";
 import { registerRootComponent } from "expo";
+import { polyfillBlob } from "./blob-polyfill";
+
+if (!global.structuredClone) {
+  var structuredClone = require("realistic-structured-clone");
+  global.structuredClone = structuredClone;
+}
+
+polyfillBlob();
 
 import App from "./src/App";
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -355,6 +355,9 @@ PODS:
     - React-callinvoker
     - React-Core
     - ReactCommon/turbomodule/core
+  - react-native-blob-jsi-helper (0.3.1):
+    - React
+    - React-Core
   - react-native-leveldb (3.3.1):
     - React-Core
   - react-native-mmkv (2.10.1):
@@ -525,6 +528,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-bignumber (from `../node_modules/react-native-bignumber`)
+  - react-native-blob-jsi-helper (from `../node_modules/react-native-blob-jsi-helper`)
   - react-native-leveldb (from `../node_modules/react-native-leveldb`)
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - react-native-quick-base64 (from `../node_modules/react-native-quick-base64`)
@@ -626,6 +630,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-bignumber:
     :path: "../node_modules/react-native-bignumber"
+  react-native-blob-jsi-helper:
+    :path: "../node_modules/react-native-blob-jsi-helper"
   react-native-leveldb:
     :path: "../node_modules/react-native-leveldb"
   react-native-mmkv:
@@ -713,6 +719,7 @@ SPEC CHECKSUMS:
   React-jsinspector: b511447170f561157547bc0bef3f169663860be7
   React-logger: c5b527272d5f22eaa09bb3c3a690fee8f237ae95
   react-native-bignumber: 9850896db4534ea31e89dfd88182e7412eace199
+  react-native-blob-jsi-helper: 13c10135af4614dbc0712afba5960784cd44f043
   react-native-leveldb: 2abee90737d7bba6399adf7767482ab5d84caa66
   react-native-mmkv: dea675cf9697ad35940f1687e98e133e1358ef9f
   react-native-quick-base64: 62290829c619fbabca4c41cfec75ae759d08fc1c

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "@react-navigation/bottom-tabs": "6.5.8",
     "@react-navigation/native": "6.1.7",
     "@react-navigation/native-stack": "6.9.13",
-    "@tbd54566975/dwn-sdk-js": "0.1.0",
+    "@tbd54566975/dwn-sdk-js": "0.2.1",
     "@tbd54566975/web5": "0.7.11",
     "@tbd54566975/web5-react-native-metro-config": "0.1.2",
     "@tbd54566975/web5-react-native-polyfills": "0.1.3",
+    "@web5/identity-agent": "0.1.0-alpha-20230823-44789a4",
     "expo": "49.0.3",
     "expo-barcode-scanner": "12.5.3",
     "expo-level": "file:assets/expo-level",
@@ -41,6 +42,7 @@
     "react": "18.2.0",
     "react-native": "0.72.3",
     "react-native-bignumber": "0.2.1",
+    "react-native-blob-jsi-helper": "0.3.1",
     "react-native-leveldb": "3.3.1",
     "react-native-mmkv": "2.10.1",
     "react-native-paper": "5.9.1",
@@ -48,8 +50,11 @@
     "react-native-quick-crypto": "0.6.1",
     "react-native-safe-area-context": "4.7.1",
     "react-native-screens": "3.22.1",
+    "readable-stream": "4.4.2",
+    "realistic-structured-clone": "3.0.0",
     "typescript": "4.9.4",
-    "verite": "0.0.6"
+    "verite": "0.0.6",
+    "web-streams-polyfill": "3.2.1"
   },
   "devDependencies": {
     "@babel/core": "7.22.9",

--- a/patches/@web5+agent+0.1.7-alpha-20230823-44789a4.patch
+++ b/patches/@web5+agent+0.1.7-alpha-20230823-44789a4.patch
@@ -1,0 +1,81 @@
+diff --git a/node_modules/@web5/agent/dist/esm/app-data-store.js b/node_modules/@web5/agent/dist/esm/app-data-store.js
+index e8e64f0..e418b51 100644
+--- a/node_modules/@web5/agent/dist/esm/app-data-store.js
++++ b/node_modules/@web5/agent/dist/esm/app-data-store.js
+@@ -11,7 +11,7 @@ import { DidKeyMethod } from '@web5/dids';
+ import { hkdf } from '@noble/hashes/hkdf';
+ import { sha256 } from '@noble/hashes/sha256';
+ import { sha512 } from '@noble/hashes/sha512';
+-import { randomBytes } from '@web5/crypto/utils';
++import { randomBytes } from '@web5/crypto/dist/esm/utils';
+ import { pbkdf2Async } from '@noble/hashes/pbkdf2';
+ import { Convert, MemoryStore } from '@web5/common';
+ import { CryptoKey, Jose, XChaCha20Poly1305 } from '@web5/crypto';
+diff --git a/node_modules/@web5/agent/dist/esm/dwn-manager.js b/node_modules/@web5/agent/dist/esm/dwn-manager.js
+index 3b68855..0c80d18 100644
+--- a/node_modules/@web5/agent/dist/esm/dwn-manager.js
++++ b/node_modules/@web5/agent/dist/esm/dwn-manager.js
+@@ -8,9 +8,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
+     });
+ };
+ import { Jose } from '@web5/crypto';
+-import * as didUtils from '@web5/dids/utils';
++import * as didUtils from '@web5/dids/dist/esm/utils';
+ import { Convert, removeUndefinedProperties } from '@web5/common';
+-import { EventLogLevel, DataStoreLevel, MessageStoreLevel, } from '@tbd54566975/dwn-sdk-js/stores';
++import { EventLogLevel, DataStoreLevel, MessageStoreLevel, } from '@tbd54566975/dwn-sdk-js/dist/esm/src/index-stores';
+ import { Cid, Dwn, Message, EventsGet, DataStream, RecordsRead, MessagesGet, RecordsWrite, RecordsQuery, DwnMethodName, RecordsDelete, ProtocolsQuery, DwnInterfaceName, ProtocolsConfigure, } from '@tbd54566975/dwn-sdk-js';
+ import { isManagedKeyPair } from './utils.js';
+ import { blobToIsomorphicNodeReadable, webReadableToIsomorphicNodeReadable } from './utils.js';
+diff --git a/node_modules/@web5/agent/dist/esm/kms-local.js b/node_modules/@web5/agent/dist/esm/kms-local.js
+index 561cc9c..4475f51 100644
+--- a/node_modules/@web5/agent/dist/esm/kms-local.js
++++ b/node_modules/@web5/agent/dist/esm/kms-local.js
+@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
+         step((generator = generator.apply(thisArg, _arguments || [])).next());
+     });
+ };
+-import { isCryptoKeyPair, checkRequiredProperty } from '@web5/crypto/utils';
++import { isCryptoKeyPair, checkRequiredProperty } from '@web5/crypto/dist/esm/utils';
+ import { EcdhAlgorithm, EcdsaAlgorithm, EdDsaAlgorithm, AesCtrAlgorithm, } from '@web5/crypto';
+ import { isManagedKey, isManagedKeyPair } from './utils.js';
+ import { KeyStoreMemory, PrivateKeyStoreMemory } from './store-managed-key.js';
+diff --git a/node_modules/@web5/agent/dist/esm/rpc-client.js b/node_modules/@web5/agent/dist/esm/rpc-client.js
+index 020df4e..c768329 100644
+--- a/node_modules/@web5/agent/dist/esm/rpc-client.js
++++ b/node_modules/@web5/agent/dist/esm/rpc-client.js
+@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
+         step((generator = generator.apply(thisArg, _arguments || [])).next());
+     });
+ };
+-import { randomUuid } from '@web5/crypto/utils';
++import { randomUuid } from '@web5/crypto/dist/esm/utils';
+ import { createJsonRpcRequest, parseJson } from './json-rpc.js';
+ /**
+  * Client used to communicate with Dwn Servers
+diff --git a/node_modules/@web5/agent/dist/esm/store-managed-key.js b/node_modules/@web5/agent/dist/esm/store-managed-key.js
+index ab4cb58..1a42192 100644
+--- a/node_modules/@web5/agent/dist/esm/store-managed-key.js
++++ b/node_modules/@web5/agent/dist/esm/store-managed-key.js
+@@ -18,7 +18,7 @@ var __rest = (this && this.__rest) || function (s, e) {
+         }
+     return t;
+ };
+-import { randomUuid } from '@web5/crypto/utils';
++import { randomUuid } from '@web5/crypto/dist/esm/utils';
+ import { Convert, removeEmptyObjects, removeUndefinedProperties } from '@web5/common';
+ import { isManagedKeyPair } from './utils.js';
+ /**
+diff --git a/node_modules/@web5/agent/dist/esm/test-managed-agent.js b/node_modules/@web5/agent/dist/esm/test-managed-agent.js
+index 2835aa0..cec93df 100644
+--- a/node_modules/@web5/agent/dist/esm/test-managed-agent.js
++++ b/node_modules/@web5/agent/dist/esm/test-managed-agent.js
+@@ -11,7 +11,7 @@ import { Jose } from '@web5/crypto';
+ import { Dwn } from '@tbd54566975/dwn-sdk-js';
+ import { LevelStore, MemoryStore } from '@web5/common';
+ import { DidIonMethod, DidKeyMethod, DidResolver, DidResolverCacheLevel } from '@web5/dids';
+-import { MessageStoreLevel, DataStoreLevel, EventLogLevel } from '@tbd54566975/dwn-sdk-js/stores';
++import { MessageStoreLevel, DataStoreLevel, EventLogLevel } from '@tbd54566975/dwn-sdk-js/dist/esm/src/index-stores';
+ import { LocalKms } from './kms-local.js';
+ import { DidManager } from './did-manager.js';
+ import { DwnManager } from './dwn-manager.js';

--- a/patches/@web5+dids+0.1.9-alpha-20230823-44789a4.patch
+++ b/patches/@web5+dids+0.1.9-alpha-20230823-44789a4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@web5/dids/dist/esm/did-key.js b/node_modules/@web5/dids/dist/esm/did-key.js
+index 420f8ab..9a0c961 100644
+--- a/node_modules/@web5/dids/dist/esm/did-key.js
++++ b/node_modules/@web5/dids/dist/esm/did-key.js
+@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
+     });
+ };
+ import { universalTypeOf } from '@web5/common';
+-import { keyToMultibaseId, multibaseIdToKey } from '@web5/crypto/utils';
++import { keyToMultibaseId, multibaseIdToKey } from '@web5/crypto/dist/esm/utils';
+ import { Jose, Ed25519, Secp256k1, EcdsaAlgorithm, EdDsaAlgorithm, } from '@web5/crypto';
+ import { getVerificationMethodTypes, parseDid } from './utils.js';
+ const SupportedCryptoAlgorithms = [

--- a/patches/react-native-blob-jsi-helper+0.3.1.patch
+++ b/patches/react-native-blob-jsi-helper+0.3.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native-blob-jsi-helper/android/src/main/cpp/cpp-adapter.cpp b/node_modules/react-native-blob-jsi-helper/android/src/main/cpp/cpp-adapter.cpp
+index 1f05fe2..faf7534 100644
+--- a/node_modules/react-native-blob-jsi-helper/android/src/main/cpp/cpp-adapter.cpp
++++ b/node_modules/react-native-blob-jsi-helper/android/src/main/cpp/cpp-adapter.cpp
+@@ -118,6 +118,11 @@ Java_com_reactnativeblobjsihelper_BlobJsiHelperModule_nativeInstall(JNIEnv *env,
+                                                              offset,
+                                                              size);
+         env->DeleteLocalRef(jstring);
++        if (env->ExceptionCheck()) {
++            env->ExceptionDescribe();
++            env->ExceptionClear();
++            throw std::runtime_error("Error calling getBufferJava");
++        }
+ 
+         jboolean isCopy = true;
+         jbyte* bytes = env->GetByteArrayElements(boxedBytes, &isCopy);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { DwnService } from "./features/dwn/dwn-service";
 import { enableLegendStateReact } from "@legendapp/state/react";
 import { StatusBar } from "expo-status-bar";
 import { linking } from "./navigation/deep-links";
+import { bootstrapIdentityAgent } from "./features/identity/identity-agent";
 
 enableLegendStateReact();
 
@@ -19,7 +20,15 @@ export const theme: typeof MD3DarkTheme = {
 
 export default function App() {
   useEffect(() => {
-    void DwnService.initExpoLevelDwn();
+    const startupTasks = async () => {
+      await DwnService.initExpoLevelDwn();
+      await bootstrapIdentityAgent(
+        "passphrase",
+        "Personal",
+        DwnService.getDwn()
+      );
+    };
+    void startupTasks();
   }, []);
 
   return (

--- a/src/features/identity/expo-level-store.ts
+++ b/src/features/identity/expo-level-store.ts
@@ -1,0 +1,31 @@
+import type { KeyValueStore } from "@web5/common";
+import { ExpoLevel } from "expo-level";
+
+export class ExpoLevelStore implements KeyValueStore<string, any> {
+  private store: ExpoLevel<string, string>;
+
+  constructor(location = "DATASTORE") {
+    this.store = new ExpoLevel(location);
+  }
+
+  async clear(): Promise<void> {
+    await this.store.clear();
+  }
+
+  async close(): Promise<void> {
+    await this.store.close();
+  }
+
+  async delete(key: string): Promise<boolean> {
+    await this.store.del(key);
+    return true;
+  }
+
+  async get(key: string): Promise<any> {
+    return await this.store.get(key);
+  }
+
+  async set(key: string, value: any): Promise<void> {
+    await this.store.put(key, value);
+  }
+}

--- a/src/features/identity/identity-agent.ts
+++ b/src/features/identity/identity-agent.ts
@@ -1,0 +1,29 @@
+import { IdentityAgent } from "@web5/identity-agent";
+import { AppDataVault, DwnManager } from "@web5/agent";
+import { ExpoLevelStore } from "./expo-level-store";
+import { Dwn } from "@tbd54566975/dwn-sdk-js";
+
+export async function bootstrapIdentityAgent(
+  passphrase: string,
+  name: string,
+  dwn: Dwn
+) {
+  const dwnManager = new DwnManager({ dwn });
+  const appData = new AppDataVault({
+    keyDerivationWorkFactor: 1,
+    store: new ExpoLevelStore("AppDataVault"),
+  });
+
+  console.log("Creating IdentityAgent...");
+  const agent = await IdentityAgent.create({ dwnManager, appData });
+  console.log("Starting IdentityAgent...");
+  await agent.start({ passphrase });
+
+  console.log(`Creating ${name} ManagedIdentity...`);
+  const identity = await agent.identityManager.create({
+    name,
+    didMethod: "ion",
+    kms: "local",
+  });
+  console.log(`Created ${identity.name} ManagedIdentity: ${identity.did}`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,7 +1336,7 @@
     ieee754 "^1.2.1"
     react-native-quick-base64 "^2.0.5"
 
-"@decentralized-identity/ion-pow-sdk@^1.0.17":
+"@decentralized-identity/ion-pow-sdk@1.0.17", "@decentralized-identity/ion-pow-sdk@^1.0.17":
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/@decentralized-identity/ion-pow-sdk/-/ion-pow-sdk-1.0.17.tgz#81213398495061de67e290ba72b49fdbc8bb5a8e"
   integrity sha512-vk7DTDM8aKDbFyu1ad/qkoRrGL4q+KvNeL/FNZXhkWPaDhVExBN/qGEoRLf1YSfFe+myto3+4RYTPut+riiqnw==
@@ -1345,7 +1345,7 @@
     cross-fetch "3.1.5"
     hash-wasm "4.9.0"
 
-"@decentralized-identity/ion-sdk@^1.0.1":
+"@decentralized-identity/ion-sdk@1.0.1", "@decentralized-identity/ion-sdk@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@decentralized-identity/ion-sdk/-/ion-sdk-1.0.1.tgz#cfcfd6b77f919d699622eb44d3693b0d31f59d67"
   integrity sha512-+P+DXcRSFjsEsI5KIqUmVjpzgUT28B2lWpTO+IxiBcfibAN/1Sg20NebGTO/+serz2CnSZf95N2a1OZ6eXypGQ==
@@ -2284,7 +2284,12 @@
     multiformats "^12.0.1"
     murmurhash3js-revisited "^3.0.0"
 
-"@noble/curves@^1.1.0":
+"@noble/ciphers@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.1.4.tgz#96327dca147829ed9eee0d96cfdf7c57915765f0"
+  integrity sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==
+
+"@noble/curves@1.1.0", "@noble/curves@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
   integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
@@ -2912,10 +2917,10 @@
     uuid "8.3.2"
     varint "6.0.0"
 
-"@tbd54566975/dwn-sdk-js@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.1.0.tgz#3dd522bcb8b79fefc03dcafc4f7890074467ccce"
-  integrity sha512-oH5s2P5855mIkPkbHeYuRWNgyQKU7nO6ccmtKYr0qMeYgIYUjBNpvIkgqllfx7ObsfLPU7myFYmlxqHAiFZGRA==
+"@tbd54566975/dwn-sdk-js@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.1.tgz#e170ad00a4a1c57a829edde19d5e14212595e9d4"
+  integrity sha512-7rFi0zvpt0F/6E2Pow5+iCnf35YGIUneI9U4J43A8NfP0Gh5S2eJkApvhrPOyt50Xq2MerFR9F5E3BE2E0jJRQ==
   dependencies:
     "@ipld/dag-cbor" "9.0.3"
     "@js-temporal/polyfill" "0.4.4"
@@ -2924,7 +2929,7 @@
     abstract-level "1.0.3"
     ajv "8.12.0"
     blockstore-core "4.2.0"
-    cross-fetch "3.1.6"
+    cross-fetch "4.0.0"
     eciesjs "0.4.0"
     flat "5.0.2"
     interface-blockstore "5.2.3"
@@ -2938,7 +2943,6 @@
     multiformats "11.0.2"
     randombytes "2.1.0"
     readable-stream "4.4.0"
-    secp256k1 "5.0.0"
     ulid "2.3.0"
     uuid "8.3.2"
     varint "6.0.0"
@@ -3267,6 +3271,83 @@
   dependencies:
     "@urql/core" ">=2.3.1"
     wonka "^4.0.14"
+
+"@web5/agent@0.1.7-alpha-20230823-44789a4":
+  version "0.1.7-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/agent/-/agent-0.1.7-alpha-20230823-44789a4.tgz#84e1221273c09e340d67c368215c45b609683a3e"
+  integrity sha512-htQSToEl2Z7OO5jy5svFkm1qhznMPvNpmYYPwxgnVo+2EPZwXPo9ohCPHrY9xHX917+gu1z64ynWD2SEQd2PXA==
+  dependencies:
+    "@tbd54566975/dwn-sdk-js" "0.2.1"
+    "@web5/common" "0.1.1-alpha-20230823-44789a4"
+    "@web5/crypto" "0.1.6-alpha-20230823-44789a4"
+    "@web5/dids" "0.1.9-alpha-20230823-44789a4"
+    level "8.0.0"
+    readable-stream "4.4.2"
+    readable-web-to-node-stream "3.0.2"
+
+"@web5/api@0.8.0-alpha-20230823-44789a4":
+  version "0.8.0-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.0-alpha-20230823-44789a4.tgz#3853662c9ecae73491bd6f7110c90149dc614c45"
+  integrity sha512-8bX5wnE2KPCZvvU65e7NAPHCTKK5+PFX9e6B+7VC2AQl7jxwNhPfpb5TSbFNZIg8LaumVAgQzBaa76m3+wcUpQ==
+  dependencies:
+    "@tbd54566975/dwn-sdk-js" "0.2.1"
+    "@web5/agent" "0.1.7-alpha-20230823-44789a4"
+    "@web5/crypto" "0.1.6-alpha-20230823-44789a4"
+    "@web5/dids" "0.1.9-alpha-20230823-44789a4"
+    "@web5/user-agent" "0.1.10-alpha-20230823-44789a4"
+    level "8.0.0"
+    ms "2.1.3"
+    readable-stream "4.4.2"
+    readable-web-to-node-stream "3.0.2"
+
+"@web5/common@0.1.1-alpha-20230823-44789a4":
+  version "0.1.1-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/common/-/common-0.1.1-alpha-20230823-44789a4.tgz#b89d8ca7d38f94e8835595aa3b642a7710818fa3"
+  integrity sha512-2H+1ABUsAAeLlePvCraA61RF4pEtYXF5o6jEi8wLQo5VSR+mHE3DzzpzTj+OmyJEpzon2b8kgn+kfOC3KbsgJQ==
+  dependencies:
+    level "8.0.0"
+    multiformats "11.0.2"
+
+"@web5/crypto@0.1.6-alpha-20230823-44789a4":
+  version "0.1.6-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/crypto/-/crypto-0.1.6-alpha-20230823-44789a4.tgz#9931d19f7c9517c5c935e52ff0aeaf8872a9be5c"
+  integrity sha512-95UVP2kzm/L7ZROJxaHis3PsuXQ9tB5ROQncoHjxu+v+CSZqXfJidepdeud29lqkWgGv1DQnuf8f1LSW67W9rg==
+  dependencies:
+    "@noble/ciphers" "0.1.4"
+    "@noble/curves" "1.1.0"
+    "@noble/hashes" "1.3.1"
+    "@web5/common" "0.1.1-alpha-20230823-44789a4"
+
+"@web5/dids@0.1.9-alpha-20230823-44789a4":
+  version "0.1.9-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.1.9-alpha-20230823-44789a4.tgz#b16b2d0b5b1e8f2ddb108bfaebf20191e1675573"
+  integrity sha512-RZxuS4snl0id8s/hMzKQufNFJoPmuTD83oHISCEtq1ENPOq9/EDMTCdVY2HaVkzXh45QewJcxt4n9a7TenUMAw==
+  dependencies:
+    "@decentralized-identity/ion-pow-sdk" "1.0.17"
+    "@decentralized-identity/ion-sdk" "1.0.1"
+    "@web5/common" "0.1.1-alpha-20230823-44789a4"
+    "@web5/crypto" "0.1.6-alpha-20230823-44789a4"
+    canonicalize "2.0.0"
+    did-resolver "4.1.0"
+    level "8.0.0"
+
+"@web5/identity-agent@0.1.0-alpha-20230823-44789a4":
+  version "0.1.0-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/identity-agent/-/identity-agent-0.1.0-alpha-20230823-44789a4.tgz#dd71586873cd68f695fc2b333615b8154a1953c4"
+  integrity sha512-ZEkn2kIboNF63+4N7aSxdP8wMSdyNNrhS6tWd44ybq22SIESRsOvcBzxd4YVI3N2oEoFzyCSWX/t0Z6Xxm4AwQ==
+  dependencies:
+    "@web5/agent" "0.1.7-alpha-20230823-44789a4"
+    "@web5/api" "0.8.0-alpha-20230823-44789a4"
+
+"@web5/user-agent@0.1.10-alpha-20230823-44789a4":
+  version "0.1.10-alpha-20230823-44789a4"
+  resolved "https://registry.yarnpkg.com/@web5/user-agent/-/user-agent-0.1.10-alpha-20230823-44789a4.tgz#ff8f785b1aac54c3d267cbd8e99cf0d8b3a1f503"
+  integrity sha512-WQq5Xc7Ein0Dn38DVraxPguAQor3PLGl3ycpz51a3fJwgJf9mMD6V5kUIr1dmnIqXaKIml32j71gRiyyfJQqFg==
+  dependencies:
+    "@web5/agent" "0.1.7-alpha-20230823-44789a4"
+    "@web5/common" "0.1.1-alpha-20230823-44789a4"
+    "@web5/crypto" "0.1.6-alpha-20230823-44789a4"
+    "@web5/dids" "0.1.9-alpha-20230823-44789a4"
 
 "@xmldom/xmldom@~0.7.7":
   version "0.7.11"
@@ -3677,6 +3758,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer-es6@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
+  integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
+
 base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -4046,7 +4132,7 @@ caniuse-lite@^1.0.30001503:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz#4461bbc895c692a96da399639cc1e146e7302a33"
   integrity sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==
 
-canonicalize@^2.0.0:
+canonicalize@2.0.0, canonicalize@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.0.0.tgz#32be2cef4446d67fd5348027a384cae28f17226a"
   integrity sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==
@@ -4413,6 +4499,13 @@ cross-fetch@3.1.6, cross-fetch@^3.1.5, cross-fetch@^3.1.6:
   dependencies:
     node-fetch "^2.6.11"
 
+cross-fetch@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4676,15 +4769,15 @@ did-jwt@^6.1.2, did-jwt@^6.2.2:
     multiformats "^9.6.5"
     uint8arrays "^3.0.0"
 
+did-resolver@4.1.0, did-resolver@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-4.1.0.tgz#740852083c4fd5bf9729d528eca5d105aff45eb6"
+  integrity sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==
+
 did-resolver@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.2.2.tgz#6f4e252a810f785d1b28a10265fad6dffee25158"
   integrity sha512-Eeo2F524VM5N3W4GwglZrnul2y6TLTwMQP3In62JdG34NZoqihYyOZLk+5wUW8sSgvIYIcJM8Dlt3xsdKZZ3tg==
-
-did-resolver@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-4.1.0.tgz#740852083c4fd5bf9729d528eca5d105aff45eb6"
-  integrity sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -4715,6 +4808,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 dotenv-expand@~10.0.0:
   version "10.0.0"
@@ -7014,7 +7114,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@4.17.21, lodash@^4.17.13, lodash@^4.17.21, lodash@^4.17.4:
+lodash@4.17.21, lodash@^4.17.13, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7792,6 +7892,13 @@ node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.11, nod
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1.2.1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -8501,7 +8608,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -8641,6 +8748,11 @@ react-native-bignumber@0.2.1:
   dependencies:
     "@craftzdog/react-native-buffer" "^6.0.4"
 
+react-native-blob-jsi-helper@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-blob-jsi-helper/-/react-native-blob-jsi-helper-0.3.1.tgz#582d982d76c1b51aa259b1c569aade4cfc148694"
+  integrity sha512-/stY23PFePcJMwQsnnySLC4aNWiJnje0i/9tQFK6JCFOE8QclgWvCvUITS5Im0SO8mR3VzDLwAhbppWBjYWpLA==
+
 react-native-leveldb@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/react-native-leveldb/-/react-native-leveldb-3.3.1.tgz#8fecf2766b421a4bfbde3a32b2c67ddb69019a2c"
@@ -8766,6 +8878,17 @@ readable-stream@4.4.0:
     events "^3.3.0"
     process "^0.11.10"
 
+readable-stream@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
+  integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
 readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
@@ -8799,6 +8922,15 @@ readline@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/readline/-/readline-1.3.0.tgz#c580d77ef2cfc8752b132498060dc9793a7ac01c"
   integrity sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==
+
+realistic-structured-clone@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz#7b518049ce2dad41ac32b421cd297075b00e3e35"
+  integrity sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==
+  dependencies:
+    domexception "^1.0.1"
+    typeson "^6.1.0"
+    typeson-registry "^1.0.0-alpha.20"
 
 recast@^0.21.0:
   version "0.21.5"
@@ -9729,6 +9861,13 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tr46@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
+  integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
+  dependencies:
+    punycode "^2.1.1"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -9870,6 +10009,20 @@ typescript@4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+typeson-registry@^1.0.0-alpha.20:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"
+  integrity sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==
+  dependencies:
+    base64-arraybuffer-es6 "^0.7.0"
+    typeson "^6.0.0"
+    whatwg-url "^8.4.0"
+
+typeson@^6.0.0, typeson@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/typeson/-/typeson-6.1.0.tgz#5b2a53705a5f58ff4d6f82f965917cabd0d7448b"
+  integrity sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==
 
 ua-parser-js@^1.0.35:
   version "1.0.35"
@@ -10157,10 +10310,25 @@ web-did-resolver@^2.0.6:
     cross-fetch "^3.1.5"
     did-resolver "^4.0.0"
 
+web-streams-polyfill@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 whatwg-fetch@^3.0.0:
   version "3.6.2"
@@ -10174,6 +10342,15 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^8.4.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
+  integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
+  dependencies:
+    lodash "^4.7.0"
+    tr46 "^2.1.0"
+    webidl-conversions "^6.1.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR pulls in the `@web5/identity-agent` package, and uses it to create an identity when the user launches the app.

Overview of the Identity Agent: https://hackmd.io/ShKU_Q9aQC6C96v7SaXl3A?view#Overview

The majority of this work was polyfills, and getting those right. For the time being, I've added those polyfills directly to this repo, as I'm not sure how to publish a new version of `web5-react-native-polyfills`. We can move these polyfills to the `web5-react-native-polyfills` repo once Tim's back from paternity leave!