### PR TITLE
fix type checking for components and mocked global state

### DIFF
--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -1,45 +1,70 @@
 import React from "react";
-import { View, Image, Text, ImageProps, StyleSheet } from "react-native";
+import {
+  View,
+  Image,
+  Text,
+  StyleSheet,
+  type ImageURISource,
+} from "react-native";
 import Octicons from "@expo/vector-icons/Octicons";
 import { Typography } from "@/theme/typography";
 import { ColorTheme } from "@/theme/colors";
 
 export const Item = (props: ItemProps) => {
-  const { heading, subtitle, body, headingSize, ...avatarProps } = props;
-  const bodyProps = { heading, subtitle, body, headingSize };
+  const { heading, subtitle, body, headingSize, badgeName, iconName, source } =
+    props;
+
   return (
     <View style={ItemStyles.row}>
-      <ItemAvatar {...avatarProps} />
-      <ItemBody {...bodyProps} />
+      <ItemAvatar badgeName={badgeName} iconName={iconName} source={source} />
+      <ItemBody
+        heading={heading}
+        subtitle={subtitle}
+        body={body}
+        headingSize={headingSize}
+      />
     </View>
   );
 };
 
 export const ItemStack = (props: ItemStackProps) => {
-  const { images, ...bodyProps } = props;
+  const { images, heading, subtitle, body, headingSize } = props;
+
   return (
     <View>
       <View style={ItemStyles.row}>
         {images.map((imageProps, index) => (
-          <ItemAvatar key={index} {...imageProps} />
+          <ItemAvatar
+            key={index}
+            source={imageProps.source}
+            iconName={imageProps.iconName}
+            badgeName={imageProps.badgeName}
+          />
         ))}
       </View>
-      <ItemBody {...bodyProps} />
+      <ItemBody
+        heading={heading}
+        subtitle={subtitle}
+        body={body}
+        headingSize={headingSize}
+      />
     </View>
   );
 };
 
-export const ItemAvatar = (props) => {
+export const ItemAvatar = (props: ItemAvatarProps) => {
   const { source, iconName, badgeName } = props;
-  if (!source && !iconName) {
-    throw new Error("Must supply either `source` or `iconName`");
-  }
+
   return (
     <View style={ItemStyles.iconAvatarContainer}>
       {source ? (
         <Image source={source} style={ItemStyles.iconAvatarImage} />
       ) : (
-        <Octicons name={iconName} size={20} style={ItemStyles.iconAvatar} />
+        <Octicons
+          name={iconName ?? "hash"}
+          size={20}
+          style={ItemStyles.iconAvatar}
+        />
       )}
       {badgeName ? (
         <View style={ItemStyles.badgeAvatarContainer}>
@@ -50,7 +75,7 @@ export const ItemAvatar = (props) => {
   );
 };
 
-export const ItemBody = (props) => {
+export const ItemBody = (props: ItemBodyProps) => {
   const { heading, subtitle, body, headingSize } = props;
   return (
     <View>
@@ -111,15 +136,16 @@ const ItemStyles = StyleSheet.create({
   },
 });
 
-type ItemAvatarProps = Partial<ImageProps> & {
+type ItemAvatarProps = {
+  source?: ImageURISource;
   iconName?: keyof typeof Octicons.glyphMap;
   badgeName?: BadgeNames;
 };
 
 type ItemBodyProps = {
-  heading;
-  subtitle?;
-  body?;
+  heading: string;
+  subtitle?: string;
+  body?: string;
   headingSize?: keyof typeof Typography;
 };
 

--- a/src/features/dwn/profile-protocol/profile-protocol.ts
+++ b/src/features/dwn/profile-protocol/profile-protocol.ts
@@ -1,4 +1,4 @@
-import { SafeOmit } from "@/types/utils";
+import type { SafeOmit } from "@/types/utils";
 import type {
   ProtocolRuleSet,
   ProtocolDefinition,

--- a/src/features/identity/ProfileManager.ts
+++ b/src/features/identity/ProfileManager.ts
@@ -1,27 +1,25 @@
-import {
+import type {
   CreateProfileOptions,
   ProfileManager as Web5ProfileManager,
 } from "@tbd54566975/web5-user-agent";
-import { DidState } from "@tbd54566975/dids";
+import Octicons from "@expo/vector-icons/Octicons";
 import { Web5 } from "@tbd54566975/web5";
 import { profilesAtom } from "@/features/identity/atoms";
-import type { Profile } from "../../types/models";
 
 export const ProfileManager: Web5ProfileManager = {
   async createProfile(
     options: CreateProfileOptions & {
       displayName?: string;
-    }
+    } & { icon: keyof typeof Octicons.glyphMap }
   ) {
     if (!options.did && !options.didMethod) {
       throw new Error("Must provide DID or DID Method");
     }
 
     try {
-      const did: DidState =
-        options.did ?? (await Web5.did.create(options.didMethod!));
+      const did = options.did ?? (await Web5.did.create(options.didMethod!));
 
-      const profile: Profile = {
+      const profile = {
         did,
         id: did.id,
         name: options.name ?? "",

--- a/src/features/identity/atoms.ts
+++ b/src/features/identity/atoms.ts
@@ -1,7 +1,7 @@
 import { observable } from "@legendapp/state";
 import { persistObservable } from "@legendapp/state/persist";
 import { ObservablePersistMMKV } from "@legendapp/state/persist-plugins/mmkv";
-import type { Profile } from "../../types/models";
+import type { Profile } from "@/types/models";
 
 export const profilesAtom = observable<Profile[]>([]);
 

--- a/src/pages/default/Tappable.tsx
+++ b/src/pages/default/Tappable.tsx
@@ -1,17 +1,23 @@
 import { Item, ItemProps } from "@/components/Item";
 import React from "react";
-import { Pressable, PressableProps, StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import Octicons from "@expo/vector-icons/Octicons";
 import { Layouts } from "@/theme/layouts";
 
-export const Tappable = (props: { options: ItemProps } & PressableProps) => {
-  const { options, ...pressableProps } = props;
-
+type Props = { onPress: () => void } & ItemProps;
+export const Tappable = (props: Props) => {
+  const { source, iconName, badgeName, heading, subtitle, onPress } = props;
   return (
     <View style={Layouts.row}>
-      <Pressable style={TappableStyles.row} {...pressableProps}>
+      <Pressable style={TappableStyles.row} onPress={onPress}>
         <View style={TappableStyles.textContainer}>
-          <Item {...options} />
+          <Item
+            iconName={iconName}
+            badgeName={badgeName}
+            source={source}
+            heading={heading}
+            subtitle={subtitle}
+          />
         </View>
         <View style={TappableStyles.iconContainer}>
           <Octicons name="chevron-right" size={24} />

--- a/src/pages/default/connections/ConnectionDetail.tsx
+++ b/src/pages/default/connections/ConnectionDetail.tsx
@@ -6,28 +6,20 @@ import { formatDID } from "@/util/formatters";
 import { Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
 import { Tappable } from "../Tappable";
-import { BadgeNames, ItemProps } from "@/components/Item";
+import { BadgeNames } from "@/components/Item";
 import { mockConnections } from "@/services/mocks";
 import { profilesAtom } from "@/features/identity/atoms";
+import { For } from "@legendapp/state/react";
+
+const tabLabels = ["About", "Connections", "Activity"];
 
 const ConnectionDetailScreen = ({ navigation, route }) => {
   const { heading: connectionName, iconName: icon } = route.params.connection;
-  const tabLabels = ["About", "Connections", "Activity"];
   const [activeTab, setActiveTab] = useState(tabLabels[0]);
 
-  const navigateToReviewConnection = (connectionPair) => {
-    navigation.navigate("ReviewConnection", { connectionPair });
+  const navigateToReviewConnection = () => {
+    navigation.navigate("ReviewConnection");
   };
-
-  //TODO: Sub this out for real connections
-  const profiles: ItemProps[] = profilesAtom.map((userProfile) => {
-    const profile = userProfile.get();
-    return {
-      heading: profile.name,
-      iconName: profile.icon as ItemProps["iconName"],
-      badgeName: BadgeNames.PROFILE,
-    };
-  });
 
   const connection = mockConnections[0];
 
@@ -61,19 +53,25 @@ const ConnectionDetailScreen = ({ navigation, route }) => {
               connected to the following profiles.
             </Text>
           </View>
-          {profiles?.map((profile, index) => (
-            <Tappable
-              key={index}
-              options={profile}
-              onPress={() =>
-                navigateToReviewConnection({
-                  connection,
-                  profile,
-                  dateCreated: "Thu Jan 1 2023",
-                })
+          <For each={profilesAtom}>
+            {(profile) => {
+              const profileData = profile.get();
+
+              if (!profileData) {
+                return <></>;
               }
-            />
-          ))}
+
+              return (
+                <Tappable
+                  key={profileData.id}
+                  heading={profileData.name}
+                  iconName={profileData.icon}
+                  badgeName={BadgeNames.PROFILE}
+                  onPress={() => navigateToReviewConnection()}
+                />
+              );
+            }}
+          </For>
         </>
       )}
       {activeTab === tabLabels[2] && <></>}

--- a/src/pages/default/connections/Connections.tsx
+++ b/src/pages/default/connections/Connections.tsx
@@ -7,7 +7,7 @@ import { observable } from "@legendapp/state";
 import { BadgeNames, ItemProps } from "@/components/Item";
 
 const ConnectionsScreen = ({ navigation }) => {
-  const navigateToItem = (connection) => {
+  const navigateToItem = (connection: ItemProps) => {
     navigation.navigate("ConnectionDetail", { connection });
   };
 
@@ -20,10 +20,13 @@ const ConnectionsScreen = ({ navigation }) => {
             if (!connection) {
               return <></>;
             }
-            const options: ItemProps = connection; // will transform this
+
             return (
               <Tappable
-                options={options}
+                heading={connection.heading}
+                subtitle={connection.subtitle}
+                iconName={connection.iconName}
+                badgeName={connection.badgeName}
                 onPress={() => navigateToItem(connection)}
               />
             );

--- a/src/pages/default/connections/ReviewConnection.tsx
+++ b/src/pages/default/connections/ReviewConnection.tsx
@@ -8,21 +8,20 @@ import { formatDID, formatDate } from "@/util/formatters";
 import React from "react";
 import { View, SafeAreaView, Text } from "react-native";
 
-const ReviewConnectionScreen = ({ route }) => {
-  //TODO Sub out with real connectionSets
-  const { connection, profile, dateCreated } = route.params.connectionSet || {
+const ReviewConnectionScreen = () => {
+  const { connection, profile } = {
     connection: {
       name: "Dignal",
-      icon: "comment-discussion",
+      icon: "comment-discussion" as const,
     },
     profile: {
       name: "Social profile",
       displayName: "Alex Aardvark",
-      icon: "hash",
+      icon: "hash" as const,
       id: "did:ion:123456789012345678901234567890",
     },
-    dateCreated: "Sat July 01 2023",
   };
+
   return (
     <SafeAreaView>
       <View style={Layouts.container}>
@@ -51,7 +50,7 @@ const ReviewConnectionScreen = ({ route }) => {
         <View>
           <LabelValueItem
             label="Connection made"
-            value={formatDate(dateCreated)}
+            value={formatDate(new Date().toString())}
           />
         </View>
         <View style={Layouts.row}>

--- a/src/pages/default/credentials/AddCredentialDetail.tsx
+++ b/src/pages/default/credentials/AddCredentialDetail.tsx
@@ -23,11 +23,7 @@ const AddCredentialDetailScreen = ({ navigation, route }) => {
     <SafeAreaView>
       <View style={Layouts.container}>
         <View style={[Layouts.row, FlexLayouts.containerHorizontalCenter]}>
-          <ItemAvatar
-            iconName="note"
-            badgeName={BadgeNames.CREDENTIAL}
-            style={Typography.textCenter}
-          />
+          <ItemAvatar iconName="note" badgeName={BadgeNames.CREDENTIAL} />
           <Text style={[Typography.heading2, Typography.textCenter]}>
             {credential.name}
           </Text>

--- a/src/pages/default/credentials/AddCredentialOptions.tsx
+++ b/src/pages/default/credentials/AddCredentialOptions.tsx
@@ -40,7 +40,6 @@ const AddCredentialOptionsScreen = ({ navigation, route }) => {
           <ItemAvatar
             iconName={credential.icon}
             badgeName={BadgeNames.CREDENTIAL}
-            style={Typography.textCenter}
           />
           <Text style={[Typography.heading2, Typography.textCenter]}>
             {credential.name}

--- a/src/pages/default/credentials/AddCredentials.tsx
+++ b/src/pages/default/credentials/AddCredentials.tsx
@@ -1,4 +1,3 @@
-import { BadgeNames, ItemProps } from "@/components/Item";
 import { Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
 import { For } from "@legendapp/state/react";
@@ -7,9 +6,10 @@ import { SafeAreaView, ScrollView, Text, View } from "react-native";
 import { Tappable } from "../Tappable";
 import { observable } from "@legendapp/state";
 import { mockCredentials } from "@/services/mocks";
+import type { Credential } from "@/types/models";
 
 const AddCredentialsScreen = ({ navigation }) => {
-  const navigateToAddCredentialDetail = (credential) => {
+  const navigateToAddCredentialDetail = (credential: Credential) => {
     navigation.navigate("AddCredentialDetail", { credential });
   };
 
@@ -26,15 +26,12 @@ const AddCredentialsScreen = ({ navigation }) => {
               if (!credential) {
                 return <></>;
               }
-              const options: ItemProps = {
-                heading: credential.name,
-                subtitle: `Issued by ${credential.issuer}`,
-                iconName: credential.icon as ItemProps["iconName"],
-                badgeName: BadgeNames.CREDENTIAL,
-              };
+
               return (
                 <Tappable
-                  options={options}
+                  heading={credential.name}
+                  subtitle={`Issued by ${credential.issuer}`}
+                  iconName={credential.icon}
                   onPress={() => navigateToAddCredentialDetail(credential)}
                 />
               );

--- a/src/pages/default/credentials/CredentialDetail.tsx
+++ b/src/pages/default/credentials/CredentialDetail.tsx
@@ -13,7 +13,6 @@ const CredentialDetailScreen = ({ route }) => {
     heading: credentialName,
     subtitle: issuerName,
     iconName: icon,
-    // ...credential
   } = route.params.credential;
 
   const credential = {

--- a/src/pages/default/credentials/Credentials.tsx
+++ b/src/pages/default/credentials/Credentials.tsx
@@ -9,7 +9,7 @@ import { FlexLayouts } from "@/theme/layouts";
 import { BadgeNames, ItemProps } from "@/components/Item";
 
 const CredentialsScreen = ({ navigation }) => {
-  const navigateToItem = (credential) => {
+  const navigateToItem = (credential: ItemProps) => {
     navigation.navigate("CredentialDetail", { credential });
   };
 
@@ -27,10 +27,14 @@ const CredentialsScreen = ({ navigation }) => {
               if (!credential) {
                 return <></>;
               }
-              const options: ItemProps = credential; // will transform this
+
               return (
                 <Tappable
-                  options={options}
+                  source={credential.source}
+                  iconName={credential.iconName}
+                  badgeName={credential.badgeName}
+                  heading={credential.heading}
+                  subtitle={credential.subtitle}
                   onPress={() => navigateToItem(credential)}
                 />
               );

--- a/src/pages/default/discover/Discover.tsx
+++ b/src/pages/default/discover/Discover.tsx
@@ -6,9 +6,10 @@ import { Tappable } from "@/pages/default/Tappable";
 import { Button } from "@/components/Button";
 import { For } from "@legendapp/state/react";
 import { observable } from "@legendapp/state";
-import { BadgeNames, ItemProps } from "@/components/Item";
+import { BadgeNames } from "@/components/Item";
 import { mockConnections, mockCredentials } from "@/services/mocks";
 import { profilesAtom } from "@/features/identity/atoms";
+import type { Credential, Connection } from "@/types/models";
 
 const DiscoverScreen = ({ navigation }) => {
   const resetProfiles = () => {
@@ -16,11 +17,11 @@ const DiscoverScreen = ({ navigation }) => {
     DevSettings.reload();
   };
 
-  const navigateToAddCredentialDetail = (credential) => {
+  const navigateToAddCredentialDetail = (credential: Credential) => {
     navigation.navigate("AddCredentialDetail", { credential });
   };
 
-  const navigateToConnectionDetail = (connection) => {
+  const navigateToConnectionDetail = (connection: Connection) => {
     navigation.navigate("ConnectionDetail", { connection });
   };
 
@@ -31,19 +32,18 @@ const DiscoverScreen = ({ navigation }) => {
         <For each={availableCredentials}>
           {(availableCredential) => {
             const credential = availableCredential.get();
+
             if (!credential) {
               return <></>;
             }
-            const options: ItemProps = {
-              heading: credential.name,
-              subtitle: `Issued by ${credential.issuer}`,
-              body: credential.description,
-              iconName: credential.icon as ItemProps["iconName"],
-              badgeName: BadgeNames.CREDENTIAL,
-            };
+
             return (
               <Tappable
-                options={options}
+                heading={credential.name}
+                subtitle={`Issued by ${credential.issuer}`}
+                body={credential.description}
+                iconName={credential.icon}
+                badgeName={BadgeNames.CREDENTIAL}
                 onPress={() => navigateToAddCredentialDetail(credential)}
               />
             );
@@ -56,14 +56,12 @@ const DiscoverScreen = ({ navigation }) => {
             if (!connection) {
               return <></>;
             }
-            const options: ItemProps = {
-              heading: connection.name,
-              iconName: connection.icon as ItemProps["iconName"],
-              badgeName: BadgeNames.CONNECTION,
-            };
+
             return (
               <Tappable
-                options={options}
+                heading={connection.name}
+                iconName={connection.icon}
+                badgeName={BadgeNames.CONNECTION}
                 onPress={() => navigateToConnectionDetail(connection)}
               />
             );
@@ -79,7 +77,5 @@ const DiscoverScreen = ({ navigation }) => {
 
 export default DiscoverScreen;
 
-const availableCredentials =
-  observable<typeof mockCredentials>(mockCredentials);
-const availableConnections =
-  observable<typeof mockConnections>(mockConnections);
+const availableCredentials = observable<Credential[]>(mockCredentials);
+const availableConnections = observable<Connection[]>(mockConnections);

--- a/src/pages/default/profiles/ProfileDetail.tsx
+++ b/src/pages/default/profiles/ProfileDetail.tsx
@@ -1,7 +1,7 @@
-import { BadgeNames, ItemProps } from "@/components/Item";
+import React, { useState } from "react";
+import { BadgeNames } from "@/components/Item";
 import { Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
-import React, { useState } from "react";
 import { View, Text } from "react-native";
 import { Tappable } from "../Tappable";
 import { LabelValueItem } from "@/components/LabelValue";
@@ -9,31 +9,16 @@ import { formatDID, formatDate } from "@/util/formatters";
 import { MenuPageLayout } from "../MenuPageLayout";
 import { mockConnections } from "@/services/mocks";
 
+const tabLabels = ["About", "Connections", "Activity"];
+
 const ProfileDetailScreen = ({ navigation, route }) => {
-  const tabLabels = ["About", "Connections", "Activity"];
   const [activeTab, setActiveTab] = useState(tabLabels[0]);
 
-  const navigateToReviewConnection = (connection) => {
-    //TODO: update to `connectionSet`
-    navigation.navigate("ReviewConnection", { connection });
+  const navigateToReviewConnection = () => {
+    navigation.navigate("ReviewConnection");
   };
 
-  const {
-    name: profileName,
-    displayName,
-    icon,
-    dateCreated,
-    id,
-  } = route.params.profile;
-
-  //TODO: Sub this out for real connections
-  const connections: ItemProps[] = mockConnections.map((connection) => {
-    return {
-      heading: connection.name,
-      iconName: connection.icon as ItemProps["iconName"],
-      badgeName: BadgeNames.CONNECTION,
-    };
-  });
+  const { name: profileName, displayName, icon, id } = route.params.profile;
 
   return (
     <MenuPageLayout
@@ -56,7 +41,10 @@ const ProfileDetailScreen = ({ navigation, route }) => {
           <LabelValueItem label="Profile label" value={profileName} />
           <LabelValueItem label="Public display name" value={displayName} />
           <LabelValueItem label="DID" value={formatDID(id)} />
-          <LabelValueItem label="Created on" value={formatDate(dateCreated)} />
+          <LabelValueItem
+            label="Created on"
+            value={formatDate(new Date().toString())}
+          />
         </>
       )}
       {activeTab === tabLabels[1] && (
@@ -67,11 +55,13 @@ const ProfileDetailScreen = ({ navigation, route }) => {
               to the following apps and services.
             </Text>
           </View>
-          {connections?.map((connection, index) => (
+          {mockConnections?.map((connection, index) => (
             <Tappable
               key={index}
-              options={connection}
-              onPress={() => navigateToReviewConnection(connection)}
+              heading={connection.name}
+              iconName={connection.icon}
+              badgeName={BadgeNames.CONNECTION}
+              onPress={() => navigateToReviewConnection()}
             />
           ))}
         </>

--- a/src/pages/default/profiles/Profiles.tsx
+++ b/src/pages/default/profiles/Profiles.tsx
@@ -5,12 +5,13 @@ import { For } from "@legendapp/state/react";
 import { ScrollView, View } from "react-native";
 import { Button } from "@/components/Button";
 import { FlexLayouts } from "@/theme/layouts";
-import { BadgeNames, ItemProps } from "@/components/Item";
+import { BadgeNames } from "@/components/Item";
 import { formatDID } from "@/util/formatters";
 import { profilesAtom } from "@/features/identity/atoms";
+import { Profile } from "@/types/models";
 
 const ProfilesScreen = ({ navigation }) => {
-  const navigateToItem = (profile) => {
+  const navigateToItem = (profile: Profile) => {
     navigation.navigate("ProfileDetail", { profile });
   };
 
@@ -28,23 +29,15 @@ const ProfilesScreen = ({ navigation }) => {
               if (!profile) {
                 return <></>;
               }
-              const options: ItemProps = {
-                heading: profile.name,
-                subtitle: profile.displayName,
-                body: formatDID(profile.id),
-                // TODO: Remove this type casting
-                iconName: profile.icon as ItemProps["iconName"],
-                badgeName: BadgeNames.PROFILE,
-              };
+
               return (
                 <Tappable
-                  options={options}
-                  onPress={() =>
-                    navigateToItem({
-                      ...profile,
-                      dateCreated: String(profile.dateCreated),
-                    })
-                  }
+                  iconName={profile.icon}
+                  badgeName={BadgeNames.PROFILE}
+                  heading={profile.name}
+                  subtitle={profile.displayName}
+                  body={formatDID(profile.id)}
+                  onPress={() => navigateToItem(profile)}
                 />
               );
             }}

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -1,4 +1,6 @@
-export const mockCredentials = [
+import type { Connection, Credential } from "@/types/models";
+
+export const mockCredentials: Credential[] = [
   {
     name: "U.S. Passport",
     issuer: "U.S. State Department",
@@ -20,7 +22,7 @@ export const mockCredentials = [
   },
 ];
 
-export const mockConnections = [
+export const mockConnections: Connection[] = [
   {
     name: "DIDPay",
     icon: "credit-card",

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,6 +1,6 @@
 import { DefaultTheme as ReactNavigationDefaultTheme } from "@react-navigation/native";
 
-export enum ColorPalette {
+enum ColorPalette {
   YELLOW = "#FFEC1A",
   CYAN = "#24F2FF",
   PURPLE = "#9A1AFF",

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,7 +1,29 @@
-import { Profile as Web5Profile } from "@tbd54566975/web5-user-agent";
+import Octicons from "@expo/vector-icons/Octicons";
+import type { DidState } from "@tbd54566975/dids";
 
-export type Profile = Web5Profile & {
+// Most data models will change over time as real protocols and data gets used rather than mocks
+export type Profile = {
+  did: DidState;
+  id: string;
+  name: string;
+  dateCreated: Date;
+  icon: keyof typeof Octicons.glyphMap;
+  connections: Connection[];
   credentials: Credential[];
-} & {
   displayName?: string;
+};
+
+export type Credential = {
+  name: string;
+  issuer: string;
+  description: string;
+  icon: keyof typeof Octicons.glyphMap;
+};
+
+export type Connection = {
+  name: string;
+  icon: keyof typeof Octicons.glyphMap;
+  developer: string;
+  description: string;
+  id: string;
 };


### PR DESCRIPTION
The goal of this PR is to bring back type checking to the project in a few ways:

- Be explicit about component interfaces rather than smashing together objects
- Decouple component interfaces from global state interfaces
- Type check temporary mocks and provide mock interfaces until global state interfaces are introduced to replace them
- Focus on only allowing only one interface for a given single parameter rather than implicitly allow multiple interfaces 

This leaves roughly 61 type errors remaining but gets us back on track. I'll handle navigation in the next pass.