### PR TITLE
Add disabled button style & fix ColorPalette type errors

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -37,6 +37,10 @@ const ButtonThemes = StyleSheet.create({
   secondary: {
     color: ColorTheme.DEFAULT,
   },
+  disabled: {
+    backgroundColor: ColorTheme.MUTED,
+    color: ColorTheme.REDUCED,
+  },
   destructive: {
     backgroundColor: ColorTheme.DANGER,
     color: ColorTheme.DEFAULT_CONTRAST,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,30 +1,31 @@
+import { ColorValue } from "react-native";
 import { DefaultTheme as ReactNavigationDefaultTheme } from "@react-navigation/native";
 
-enum ColorPalette {
-  YELLOW = "#FFEC1A",
-  CYAN = "#24F2FF",
-  PURPLE = "#9A1AFF",
-  RED = "#EB4526",
-  GREEN = "#32BF00",
-  WHITE = "#FFFFFF",
-  BLACK = "#000000",
-  GRAY_50 = "#F1F1F1",
-  GRAY_200 = "#D3D3D3",
-  GRAY_400 = "#AFAFAF",
-  GRAY_600 = "#7C7C7C",
-  GRAY_800 = "#343434",
-  GRAY_900 = "#202020",
-}
+const ColorPalette: Record<string, ColorValue> = {
+  YELLOW: "#FFEC1A",
+  CYAN: "#24F2FF",
+  PURPLE: "#9A1AFF",
+  RED: "#EB4526",
+  GREEN: "#32BF00",
+  WHITE: "#FFFFFF",
+  BLACK: "#000000",
+  GRAY_50: "#F1F1F1",
+  GRAY_200: "#D3D3D3",
+  GRAY_400: "#AFAFAF",
+  GRAY_600: "#7C7C7C",
+  GRAY_800: "#343434",
+  GRAY_900: "#202020",
+};
 
-export enum ColorTheme {
-  DEFAULT = ColorPalette.BLACK,
-  DEFAULT_CONTRAST = ColorPalette.WHITE,
-  REDUCED = ColorPalette.GRAY_600,
-  MUTED = ColorPalette.GRAY_400,
-  PRIMARY = ColorPalette.YELLOW,
-  SUCCESS = ColorPalette.GREEN,
-  DANGER = ColorPalette.RED,
-}
+export const ColorTheme: Record<string, ColorValue> = {
+  DEFAULT: ColorPalette.BLACK,
+  DEFAULT_CONTRAST: ColorPalette.WHITE,
+  REDUCED: ColorPalette.GRAY_600,
+  MUTED: ColorPalette.GRAY_400,
+  PRIMARY: ColorPalette.YELLOW,
+  SUCCESS: ColorPalette.GREEN,
+  DANGER: ColorPalette.RED,
+};
 
 // Monochrome theme gives us fine-grained control over color palette
 export const DefaultTheme = {


### PR DESCRIPTION
This PR does two things (each in their own separate commit):

1. Adds a "disabled" button theme. Below is a screenshot of how it looks in the app

![Simulator Screenshot - iPhone 14 Pro - 2023-09-08 at 10 38 43](https://github.com/TBD54566975/web5-wallet/assets/88001738/5faf1462-afcb-4fa8-be9e-4d793c1a8e26)


3. Fixes type errors when using `ColorTheme` by changing them to Records instead of an enum.
    * `ColorTheme` is currently an enum. But when we use it to provide colors for components, they expect `ColorValue` objects. This resulted in type errors when using them to create styles (see screenshot below for exact wording).

![Screenshot 2023-09-08 at 10 48 38 AM](https://github.com/TBD54566975/web5-wallet/assets/88001738/295a3d5e-1470-43dd-abef-2af843b10c96)