### PR TITLE
tsconfig react jsx

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     "isolatedModules": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true
+    "strict": true,
+    "jsx": "react"
   },
-  "extends": "expo/tsconfig.base",
   "include": [".eslintrc.js", "**/*"],
   "exclude": ["./src/reference/**/*"]
 }


### PR DESCRIPTION
(accidentally committed this to directly to `main`, when I meant to make this a PR. Reverted the change on main, and I'm opening up this PR now!)

Two tsconfig.json changes:
1. Set the JSX compiler option to `react`. This fixes type warnings for pages that return JSX. Attaching image of error I was seeing
![Screenshot 2023-09-11 at 1 50 20 PM](https://github.com/TBD54566975/web5-wallet/assets/88001738/067393fe-d193-4533-998e-596c8c72bbe8)


2.  Remove the `"extends": "expo/tsconfig.base"` configuration. This doesn't seem to be a valid file, as there's no `expo` folder in our folder structure.