### PR TITLE
Prefix existing model types with 'Mock'

### DIFF
--- a/src/features/identity/atoms.ts
+++ b/src/features/identity/atoms.ts
@@ -1,9 +1,9 @@
 import { observable } from "@legendapp/state";
 import { persistObservable } from "@legendapp/state/persist";
 import { ObservablePersistMMKV } from "@legendapp/state/persist-plugins/mmkv";
-import type { Profile } from "@/types/models";
+import type { MockProfile } from "@/types/models";
 
-export const profilesAtom = observable<Profile[]>([]);
+export const profilesAtom = observable<MockProfile[]>([]);
 
 persistObservable(profilesAtom, {
   local: "profiles",

--- a/src/pages/default/credentials/AddCredentialDetail.tsx
+++ b/src/pages/default/credentials/AddCredentialDetail.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { SafeAreaView, View, Text, StyleSheet } from "react-native";
 import Octicons from "@expo/vector-icons/Octicons";
 import { mockCredentials } from "@/services/mocks";
-import type { Credential } from "@/types/models";
+import type { MockCredential } from "@/types/models";
 import { AppNavigatorProps } from "@/types/navigation";
 
 type Props = AppNavigatorProps<"AddCredentialDetailScreen">;
@@ -18,7 +18,9 @@ const AddCredentialDetailScreen = ({ navigation, route }: Props) => {
     navigation.navigate("AddCredentialOptionsScreen", { credential });
   };
 
-  const navigateToAddCredentialDetail = (secondaryCredential: Credential) => {
+  const navigateToAddCredentialDetail = (
+    secondaryCredential: MockCredential
+  ) => {
     navigation.push("AddCredentialDetailScreen", {
       credential: secondaryCredential,
     });

--- a/src/pages/default/credentials/AddCredentials.tsx
+++ b/src/pages/default/credentials/AddCredentials.tsx
@@ -6,12 +6,12 @@ import { SafeAreaView, ScrollView, Text, View } from "react-native";
 import { Tappable } from "../Tappable";
 import { observable } from "@legendapp/state";
 import { mockCredentials } from "@/services/mocks";
-import type { Credential } from "@/types/models";
+import type { MockCredential } from "@/types/models";
 import { AppNavigatorProps } from "@/types/navigation";
 
 type Props = AppNavigatorProps<"AddCredentialsScreen">;
 const AddCredentialsScreen = ({ navigation }: Props) => {
-  const navigateToAddCredentialDetail = (credential: Credential) => {
+  const navigateToAddCredentialDetail = (credential: MockCredential) => {
     navigation.navigate("AddCredentialDetailScreen", { credential });
   };
 

--- a/src/pages/default/discover/Discover.tsx
+++ b/src/pages/default/discover/Discover.tsx
@@ -9,7 +9,7 @@ import { observable } from "@legendapp/state";
 import { BadgeNames } from "@/components/Item";
 import { mockConnections, mockCredentials } from "@/services/mocks";
 import { profilesAtom } from "@/features/identity/atoms";
-import type { Credential, Connection } from "@/types/models";
+import type { MockCredential, MockConnection } from "@/types/models";
 import type { TabNavigatorProps } from "@/types/navigation";
 
 type Props = TabNavigatorProps<"DiscoverScreen">;
@@ -19,11 +19,11 @@ const DiscoverScreen = ({ navigation }: Props) => {
     DevSettings.reload();
   };
 
-  const navigateToAddCredentialDetail = (credential: Credential) => {
+  const navigateToAddCredentialDetail = (credential: MockCredential) => {
     navigation.navigate("AddCredentialDetailScreen", { credential });
   };
 
-  const navigateToConnectionDetail = (connection: Connection) => {
+  const navigateToConnectionDetail = (connection: MockConnection) => {
     navigation.navigate("ConnectionDetailScreen", {
       heading: connection.name,
       iconName: connection.icon,
@@ -80,5 +80,5 @@ const DiscoverScreen = ({ navigation }: Props) => {
 
 export default DiscoverScreen;
 
-const availableCredentials = observable<Credential[]>(mockCredentials);
-const availableConnections = observable<Connection[]>(mockConnections);
+const availableCredentials = observable<MockCredential[]>(mockCredentials);
+const availableConnections = observable<MockConnection[]>(mockConnections);

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -1,6 +1,6 @@
-import type { Connection, Credential } from "@/types/models";
+import type { MockConnection, MockCredential } from "@/types/models";
 
-export const mockCredentials: Credential[] = [
+export const mockCredentials: MockCredential[] = [
   {
     name: "U.S. Passport",
     issuer: "U.S. State Department",
@@ -22,7 +22,7 @@ export const mockCredentials: Credential[] = [
   },
 ];
 
-export const mockConnections: Connection[] = [
+export const mockConnections: MockConnection[] = [
   {
     name: "DIDPay",
     icon: "credit-card",

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -2,25 +2,25 @@ import Octicons from "@expo/vector-icons/Octicons";
 import type { DidState } from "@tbd54566975/dids";
 
 // Most data models will change over time as real protocols and data gets used rather than mocks
-export type Profile = {
+export type MockProfile = {
   did: DidState;
   id: string;
   name: string;
   dateCreated: Date;
   icon: keyof typeof Octicons.glyphMap;
-  connections: Connection[];
-  credentials: Credential[];
+  connections: MockConnection[];
+  credentials: MockCredential[];
   displayName: string;
 };
 
-export type Credential = {
+export type MockCredential = {
   name: string;
   issuer: string;
   description: string;
   icon: keyof typeof Octicons.glyphMap;
 };
 
-export type Connection = {
+export type MockConnection = {
   name: string;
   icon: keyof typeof Octicons.glyphMap;
   developer: string;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -5,7 +5,7 @@ import type {
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
 import type Octicons from "@expo/vector-icons/Octicons";
-import type { Credential, Profile } from "@/types/models";
+import type { MockCredential, MockProfile } from "@/types/models";
 
 export type AppNavigatorInterface = {
   WelcomeScreen: undefined;
@@ -14,7 +14,7 @@ export type AppNavigatorInterface = {
   CreateWalletScreen: { passphrase: string };
   EnterPassphraseScreen: undefined;
   Tabs: NavigatorScreenParams<TabNavigatorInterface>;
-  ProfileDetailScreen: { profile: Profile };
+  ProfileDetailScreen: { profile: MockProfile };
   CredentialDetailScreen: {
     heading: string;
     subtitle: string;
@@ -22,8 +22,8 @@ export type AppNavigatorInterface = {
   };
   AddProfileScreen: undefined;
   AddCredentialsScreen: undefined;
-  AddCredentialDetailScreen: { credential: Credential };
-  AddCredentialOptionsScreen: { credential: Credential };
+  AddCredentialDetailScreen: { credential: MockCredential };
+  AddCredentialOptionsScreen: { credential: MockCredential };
   ConnectionDetailScreen: {
     heading: string;
     iconName: keyof typeof Octicons.glyphMap;


### PR DESCRIPTION
Currently, there are a few mocked out types defined in the [src/types/models.ts file](https://github.com/TBD54566975/web5-wallet/blob/1f6ad55295acefb578ab1797a2f26067f8775547/src/types/models.ts). 

These types were used to mock out the user interfaces, as we didn't have any real types to build with at that point.

However, now REAL types are getting added to the project that will be stored as records in the DWN (eg: via the [profile-protocol](https://github.com/TBD54566975/web5-wallet/blob/1f6ad55295acefb578ab1797a2f26067f8775547/src/features/dwn/profile-protocol/profile-protocol.ts)). This overloading terms like `Profile`. 

To be very explicit which types represented mocked out data, this PR prefixes all of the types we used for mocking out the UI with a `Mock` prefix.
