### PR TITLE
Use profile protocol to store & display displayName for Profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tbd54566975/web5": "0.7.11",
     "@tbd54566975/web5-react-native-metro-config": "0.1.3",
     "@tbd54566975/web5-react-native-polyfills": "0.1.3",
+    "@web5/api": "0.8.1",
     "@web5/identity-agent": "0.2.0",
     "expo": "49.0.3",
     "expo-barcode-scanner": "12.5.3",

--- a/src/features/dwn/profile-protocol/profile-protocol.ts
+++ b/src/features/dwn/profile-protocol/profile-protocol.ts
@@ -18,6 +18,13 @@ export const profileProtocol = {
           who: "anyone",
           can: "read",
         },
+        // TODO: remove the following rule.
+        // This only exists currently due to a bug where ManagedIdentities
+        // aren't being considered the DWN's tentant.
+        {
+          who: "anyone",
+          can: "write",
+        },
       ],
     },
   },

--- a/src/features/dwn/profile-protocol/profile-protocol.ts
+++ b/src/features/dwn/profile-protocol/profile-protocol.ts
@@ -1,3 +1,7 @@
+export type Profile = {
+  displayName: string;
+};
+
 // TODO: Needs to be fixed depending on what we do with Protocols: https://github.com/TBD54566975/web5-wallet/issues/66
 export const profileProtocol = {
   protocol: "http://garfield.com/profile.schema.json",

--- a/src/features/identity/IdentityAgentManager.ts
+++ b/src/features/identity/IdentityAgentManager.ts
@@ -1,10 +1,14 @@
 import { IdentityAgent } from "@web5/identity-agent";
 import {
   type CreateDidMethodOptions,
-  type ManagedIdentity,
   AppDataVault,
   DwnManager,
 } from "@web5/agent";
+import { Web5 } from "@web5/api";
+import {
+  profileProtocol,
+  Profile,
+} from "@/features/dwn/profile-protocol/profile-protocol";
 import {
   MessageStoreLevel,
   DataStoreLevel,
@@ -75,6 +79,7 @@ const startAgent = async (passphrase: string) => {
 
 const createIdentity = async (
   name: string,
+  displayName: string,
   didMethod: keyof CreateDidMethodOptions = "ion",
   kms = "local"
 ) => {
@@ -89,6 +94,29 @@ const createIdentity = async (
   await agent.identityManager.import({
     identity,
     context: agent.agentDid,
+  });
+
+  // Install the profile protocol in the DWN, for the newly created identity tenant
+  const web5 = new Web5({ agent, connectedDid: identity.did });
+  // const configureResponse = await web5.dwn.protocols.configure({
+  //   message: {
+  //     definition: profileProtocol,
+  //   },
+  // });
+  // console.log("Configure response:", JSON.stringify(configureResponse));
+
+  // Write a profile
+  const profile: Profile = {
+    displayName,
+  };
+  await web5.dwn.records.write({
+    data: profile,
+    message: {
+      schema: profileProtocol.types.profile.schema,
+      // protocol: profileProtocol.protocol,
+      // protocolPath: "displayName",
+    },
+    store: true,
   });
 };
 

--- a/src/features/identity/IdentityAgentManager.ts
+++ b/src/features/identity/IdentityAgentManager.ts
@@ -1,6 +1,7 @@
 import { IdentityAgent } from "@web5/identity-agent";
 import {
   type CreateDidMethodOptions,
+  type ManagedIdentity,
   AppDataVault,
   DwnManager,
 } from "@web5/agent";
@@ -98,12 +99,11 @@ const createIdentity = async (
 
   // Install the profile protocol in the DWN, for the newly created identity tenant
   const web5 = new Web5({ agent, connectedDid: identity.did });
-  // const configureResponse = await web5.dwn.protocols.configure({
-  //   message: {
-  //     definition: profileProtocol,
-  //   },
-  // });
-  // console.log("Configure response:", JSON.stringify(configureResponse));
+  await web5.dwn.protocols.configure({
+    message: {
+      definition: profileProtocol,
+    },
+  });
 
   // Write a profile
   const profile: Profile = {
@@ -113,8 +113,8 @@ const createIdentity = async (
     data: profile,
     message: {
       schema: profileProtocol.types.profile.schema,
-      // protocol: profileProtocol.protocol,
-      // protocolPath: "displayName",
+      protocol: profileProtocol.protocol,
+      protocolPath: "profile",
     },
     store: true,
   });
@@ -124,10 +124,15 @@ const listIdentities = () => {
   return agent.identityManager.list();
 };
 
+const web5 = (identity: ManagedIdentity): Web5 => {
+  return new Web5({ agent, connectedDid: identity.did });
+};
+
 export const IdentityAgentManager = {
   initAgent,
   isFirstLaunch,
   startAgent,
   createIdentity,
   listIdentities,
+  web5,
 };

--- a/src/pages/default/profiles/AddProfile.tsx
+++ b/src/pages/default/profiles/AddProfile.tsx
@@ -14,7 +14,7 @@ const AddProfileScreen = ({ navigation }: Props) => {
   const [displayName, setDisplayName] = useState("");
 
   const addProfile = async () => {
-    await IdentityAgentManager.createIdentity(profileName);
+    await IdentityAgentManager.createIdentity(profileName, displayName);
     navigation.goBack();
   };
 

--- a/src/pages/default/profiles/Profiles.tsx
+++ b/src/pages/default/profiles/Profiles.tsx
@@ -7,20 +7,71 @@ import { FlexLayouts } from "@/theme/layouts";
 import { formatDID } from "@/util/formatters";
 import { TabNavigatorProps } from "@/types/navigation";
 import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
-import { type ManagedIdentity } from "@web5/agent";
+import {
+  Profile,
+  profileProtocol,
+} from "@/features/dwn/profile-protocol/profile-protocol";
+import type { ManagedIdentity } from "@web5/agent";
+
+type Row = {
+  identity: ManagedIdentity;
+  profile: Profile;
+};
 
 type Props = TabNavigatorProps<"ProfilesScreen">;
+
 const ProfilesScreen = ({ navigation }: Props) => {
-  const [managedIdentities, setManagedIdentities] = useState<ManagedIdentity[]>(
-    []
-  );
+  const [rows, setRows] = useState<Row[]>([]);
+
   useEffect(() => {
-    const fetchManagedIdentities = async () => {
+    const fetchRows = async () => {
       const managedIdentities = await IdentityAgentManager.listIdentities();
-      setManagedIdentities(managedIdentities);
+      const unfilteredRows = await Promise.all(
+        managedIdentities.map(async (identity): Promise<Row | undefined> => {
+          const web5 = IdentityAgentManager.web5(identity);
+
+          const queryResult = await web5.dwn.records.query({
+            message: {
+              filter: {
+                protocol: profileProtocol.protocol,
+                protocolPath: "profile",
+              },
+            },
+          });
+
+          // The Records returned with a query result DO NOT have access
+          // to the data. Get the recordId we're interested in and
+          // make an explicit read request to acquire a Record that DOES
+          // have access to the data.
+          const recordId = queryResult.records?.at(0)?.id;
+          if (!recordId) {
+            return undefined;
+          }
+
+          const readResult = await web5.dwn.records.read({
+            message: {
+              recordId,
+            },
+          });
+
+          if (!readResult) {
+            return undefined;
+          }
+
+          const profile = (await readResult.record.data.json()) as Profile;
+
+          return {
+            identity,
+            profile,
+          };
+        })
+      );
+
+      const rows = unfilteredRows.filter((row) => row !== undefined) as Row[];
+      setRows(rows);
     };
 
-    void fetchManagedIdentities();
+    void fetchRows();
   }, []);
 
   const navigateToAddProfile = () => {
@@ -31,13 +82,14 @@ const ProfilesScreen = ({ navigation }: Props) => {
     <ParentPageLayout>
       <View style={FlexLayouts.containerButtonBottom}>
         <ScrollView>
-          {managedIdentities.map((identity) => (
+          {rows.map((row) => (
             <Tappable
-              key={identity.did}
+              key={row.identity.did}
               iconName="hash"
-              heading={identity.name}
-              body={formatDID(identity.did)}
-              onPress={() => console.log("tapped", identity.name)}
+              heading={row.identity.name}
+              subtitle={row.profile.displayName}
+              body={formatDID(row.identity.did)}
+              onPress={() => console.log("tapped", row.identity.name)}
             />
           ))}
         </ScrollView>

--- a/src/pages/onboarding/create/CreateWallet.tsx
+++ b/src/pages/onboarding/create/CreateWallet.tsx
@@ -10,15 +10,16 @@ type Props = AppNavigatorProps<"CreateWalletScreen">;
 
 const CreateWalletScreen = ({ navigation, route }: Props) => {
   useEffect(() => {
-    console.log("Starting to create identities");
-
     const createWallet = async () => {
       try {
         await IdentityAgentManager.startAgent(route.params.passphrase);
 
         const defaultIdentityCreatePromises = defaultIdentities.map(
           (identity) => {
-            return IdentityAgentManager.createIdentity(identity.name);
+            return IdentityAgentManager.createIdentity(
+              identity.name,
+              identity.displayName
+            );
           }
         );
         await Promise.all(defaultIdentityCreatePromises);

--- a/src/pages/onboarding/create/default_identities.ts
+++ b/src/pages/onboarding/create/default_identities.ts
@@ -14,7 +14,7 @@ export const defaultIdentities: NewIdentityProps[] = [
   },
   {
     name: "Professional",
-    displayName: "Alex Aardvark",
+    displayName: "Bo Jangles",
     icon: "briefcase",
   },
 ];


### PR DESCRIPTION
When a new identity is created, this PR will install the [profileProtocol](https://github.com/TBD54566975/web5-wallet/blob/main/src/features/dwn/profile-protocol/profile-protocol.ts) to that identity's DWN. Then immediately after installing the protocol, a profile is written to the DWN with information set according to the default identities (defined [here](https://github.com/TBD54566975/web5-wallet/blob/main/src/pages/onboarding/create/default_identities.ts#L9)).

Profile is currently just a `displayName`, but will evolve to hold more information in the future. 

## Demo
https://github.com/TBD54566975/web5-wallet/assets/88001738/740f5a53-3878-4fd5-849f-45fb90a39f58

