### PR TITLE
Fetch data via a custom hook to for loading state logic

### DIFF
--- a/src/hooks/useFetchData.ts
+++ b/src/hooks/useFetchData.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useCallback } from "react";
+
+type FetchResult<T> = {
+  data: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+};
+
+const useFetchData = <T>(
+  fetchDataFunction: () => Promise<T>
+): FetchResult<T> => {
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const result = await fetchDataFunction();
+      setData(result);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err);
+      } else {
+        setError(new Error(String(err)));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchDataFunction]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error };
+};
+
+export default useFetchData;

--- a/src/pages/default/profiles/ProfileDetail.tsx
+++ b/src/pages/default/profiles/ProfileDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { BadgeNames } from "@/components/Item";
 import { Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
@@ -9,15 +9,15 @@ import { formatDID, formatDate } from "@/util/formatters";
 import { MenuPageLayout } from "../MenuPageLayout";
 import { mockConnections } from "@/services/mocks";
 import { AppNavigatorProps } from "@/types/navigation";
-import { Profile } from "@/features/dwn/profile-protocol/profile-protocol";
 import { fetchProfile } from "@/features/identity/fetch-profile";
+import useFetchData from "@/hooks/useFetchData";
+import LoadingScreen from "@/pages/Loading";
 
 const tabLabels = ["About", "Connections", "Activity"];
 
 type Props = AppNavigatorProps<"ProfileDetailScreen">;
 const ProfileDetailScreen = ({ navigation, route }: Props) => {
   const [activeTab, setActiveTab] = useState(tabLabels[0]);
-  const [profile, setProfile] = useState<Profile | undefined>(undefined);
 
   const navigateToReviewConnection = () => {
     navigation.navigate("ReviewConnectionScreen");
@@ -25,13 +25,13 @@ const ProfileDetailScreen = ({ navigation, route }: Props) => {
 
   const { identity } = route.params;
 
-  useEffect(() => {
-    const loadData = async () => {
-      const profile = await fetchProfile(identity);
-      setProfile(profile);
-    };
-    void loadData();
-  }, [identity]);
+  const { data: profile, loading } = useFetchData(async () => {
+    return await fetchProfile(identity);
+  });
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
 
   return (
     <MenuPageLayout

--- a/src/pages/default/profiles/Profiles.tsx
+++ b/src/pages/default/profiles/Profiles.tsx
@@ -1,15 +1,17 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { ParentPageLayout } from "@/pages/default/ParentPageLayout";
 import { Tappable } from "@/pages/default/Tappable";
-import { ScrollView, View } from "react-native";
+import { ActivityIndicator, ScrollView, View } from "react-native";
 import { Button } from "@/components/Button";
-import { FlexLayouts } from "@/theme/layouts";
+import { FlexLayouts, Layouts } from "@/theme/layouts";
 import { formatDID } from "@/util/formatters";
 import { TabNavigatorProps } from "@/types/navigation";
 import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
 import { Profile } from "@/features/dwn/profile-protocol/profile-protocol";
 import type { ManagedIdentity } from "@web5/agent";
 import { fetchProfile } from "@/features/identity/fetch-profile";
+import useFetchData from "@/hooks/useFetchData";
+import LoadingScreen from "@/pages/Loading";
 
 type Row = {
   identity: ManagedIdentity;
@@ -19,31 +21,25 @@ type Row = {
 type Props = TabNavigatorProps<"ProfilesScreen">;
 
 const ProfilesScreen = ({ navigation }: Props) => {
-  const [rows, setRows] = useState<Row[]>([]);
+  const { data: rows, loading } = useFetchData(async () => {
+    const managedIdentities = await IdentityAgentManager.listIdentities();
+    const unfilteredRows = await Promise.all(
+      managedIdentities.map(async (identity): Promise<Row | undefined> => {
+        const profile = await fetchProfile(identity);
+        if (!profile) {
+          return undefined;
+        }
 
-  useEffect(() => {
-    const fetchRows = async () => {
-      const managedIdentities = await IdentityAgentManager.listIdentities();
-      const unfilteredRows = await Promise.all(
-        managedIdentities.map(async (identity): Promise<Row | undefined> => {
-          const profile = await fetchProfile(identity);
-          if (!profile) {
-            return undefined;
-          }
+        return {
+          identity,
+          profile,
+        };
+      })
+    );
 
-          return {
-            identity,
-            profile,
-          };
-        })
-      );
-
-      const rows = unfilteredRows.filter((row) => row !== undefined) as Row[];
-      setRows(rows);
-    };
-
-    void fetchRows();
-  }, []);
+    const rows = unfilteredRows.filter((row) => row !== undefined) as Row[];
+    return rows;
+  });
 
   const navigateToProfile = (identity: ManagedIdentity) => {
     navigation.navigate("ProfileDetailScreen", { identity });
@@ -53,11 +49,15 @@ const ProfilesScreen = ({ navigation }: Props) => {
     navigation.navigate("AddProfileScreen");
   };
 
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
   return (
     <ParentPageLayout>
       <View style={FlexLayouts.containerButtonBottom}>
         <ScrollView>
-          {rows.map((row) => (
+          {rows?.map((row) => (
             <Tappable
               key={row.identity.did}
               iconName="hash"


### PR DESCRIPTION
`ProfilesScreen` and `ProfileDetailScreen` both need to fetch the profile data from the DWN to display it to the user. 

Currently, that data loading is being done in the background, and will pop into view once the operation has completed. This is a little confusing, as the user is presented either a blank or partial screen, and then the content just jumps onto the screen.

To prevent this jarring behavior, this PR introduces a new `useFetchData` hook. This hook provides three pieces of information to the caller:
* loading status
* the data itself (available once loading has completed)
* the error if something bad happened (available once the loading has completed)

The two screens use this information to show a loading indicator while waiting for this information to be fetched from the DWN.