### PR TITLE
export queryclient singleton

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,8 @@ import { type LinkingOptions } from "@react-navigation/native";
 import { AppNavigator } from "./navigation/AppNavigator";
 import { NavigationContainer } from "@react-navigation/native";
 import { DefaultTheme } from "./theme/colors";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "@/features/app/store";
 
 enableLegendStateReact();
 
@@ -16,8 +17,6 @@ const DeepLinkConfig: LinkingOptions<any> = {
     },
   },
 };
-
-const queryClient = new QueryClient();
 
 const App = () => {
   return (

--- a/src/features/app/store.ts
+++ b/src/features/app/store.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();


### PR DESCRIPTION
makes it so the queryClient can just be imported rather than passing it around