### PR TITLE
Delay handling deeplinks until user has unlocked their wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,18 @@
 import React from "react";
 import { enableLegendStateReact } from "@legendapp/state/react";
-import { type LinkingOptions } from "@react-navigation/native";
 import { AppNavigator } from "./navigation/AppNavigator";
 import { NavigationContainer } from "@react-navigation/native";
 import { DefaultTheme } from "./theme/colors";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/features/app/store";
+import { Deeplink } from "@/features/deeplink/deeplink";
 
 enableLegendStateReact();
-
-const DeepLinkConfig: LinkingOptions<any> = {
-  prefixes: ["web5://"],
-  config: {
-    screens: {
-      PermissionRequestScreen: ":host/permission",
-    },
-  },
-};
 
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <NavigationContainer linking={DeepLinkConfig} theme={DefaultTheme}>
+      <NavigationContainer linking={Deeplink.config} theme={DefaultTheme}>
         <AppNavigator />
       </NavigationContainer>
     </QueryClientProvider>

--- a/src/features/deeplink/deeplink.ts
+++ b/src/features/deeplink/deeplink.ts
@@ -1,0 +1,36 @@
+import { Linking } from "react-native";
+import { type LinkingOptions } from "@react-navigation/native";
+import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
+
+let delayedDeeplink: string | null = null;
+
+const config: LinkingOptions<any> = {
+  prefixes: ["web5://"],
+  filter: (url) => {
+    // Do not handle any deeplinks until the IdentityAgent has been started.
+    // If a deeplink comes in before the agent has been started, delay handling
+    // it until the user has fully started the agent by enterin their passphrase.
+    const isAgentStarted = IdentityAgentManager.isAgentStarted();
+    if (!isAgentStarted) {
+      delayedDeeplink = url;
+    }
+    return isAgentStarted;
+  },
+  config: {
+    screens: {
+      ConnectionRequestScreen: ":host/permission",
+    },
+  },
+};
+
+const openDelayedDeeplinkIfNeeded = async () => {
+  if (delayedDeeplink) {
+    await Linking.openURL(delayedDeeplink);
+    delayedDeeplink = null;
+  }
+};
+
+export const Deeplink = {
+  config,
+  openDelayedDeeplinkIfNeeded,
+};

--- a/src/features/identity/IdentityAgentManager.ts
+++ b/src/features/identity/IdentityAgentManager.ts
@@ -1,6 +1,7 @@
 import { IdentityAgent } from "@web5/identity-agent";
 import {
   type CreateDidMethodOptions,
+  type ManagedIdentity,
   AppDataVault,
   DwnManager,
   SyncManagerLevel,
@@ -24,6 +25,7 @@ import ms from "ms";
 
 // Singleton
 let agent: IdentityAgent;
+let isStarted = false;
 
 const initAgent = async () => {
   if (agent) {
@@ -77,9 +79,14 @@ const isFirstLaunch = async () => {
   return await agent.firstLaunch();
 };
 
+const isAgentStarted = () => {
+  return isStarted;
+};
+
 const startAgent = async (passphrase: string) => {
   await agent.start({ passphrase });
   await startSync();
+  isStarted = true;
 };
 
 const startSync = async () => {
@@ -154,6 +161,7 @@ const web5 = (identity: ManagedIdentity): Web5 => {
 export const IdentityAgentManager = {
   initAgent,
   isFirstLaunch,
+  isAgentStarted,
   startAgent,
   createIdentity,
   listIdentities,

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -20,6 +20,7 @@ import type { AppNavigatorInterface } from "@/types/navigation";
 import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
 import LoadingScreen from "@/pages/Loading";
 import EnterPassphraseScreen from "@/pages/default/passphrase/EnterPassphrase";
+import ConnectionRequestScreen from "@/pages/default/connections/ConnectionRequest";
 
 const Stack = createNativeStackNavigator<AppNavigatorInterface>();
 
@@ -100,6 +101,14 @@ export const AppNavigator = () => {
           component={ReviewConnectionScreen}
         />
       </Stack.Group>
+
+      {/* Full Screen Modals */}
+      <Stack.Group screenOptions={fullscreenModalGroupOptions}>
+        <Stack.Screen
+          name="ConnectionRequestScreen"
+          component={ConnectionRequestScreen}
+        />
+      </Stack.Group>
     </Stack.Navigator>
   );
 };
@@ -107,10 +116,16 @@ export const AppNavigator = () => {
 const appNavigatorOptions: NativeStackNavigationOptions = {
   headerShown: false,
 };
+
 const authedGroupOptions: NativeStackNavigationOptions = {
   headerShown: true,
   headerTitle: () => false,
   headerShadowVisible: false,
   headerBackTitleVisible: false,
   // headerBackImageSource: TODO: add arrow image source here
+};
+
+const fullscreenModalGroupOptions: NativeStackNavigationOptions = {
+  animation: "slide_from_bottom",
+  presentation: "fullScreenModal",
 };

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   type BottomTabNavigationOptions,
   createBottomTabNavigator,
@@ -13,10 +13,35 @@ import { Typography } from "@/theme/typography";
 import { ColorTheme } from "@/theme/colors";
 import { SPACE } from "@/theme/layouts";
 import { type TabNavigatorInterface } from "@/types/navigation";
+import { type AppStateStatus } from "react-native/types";
+import { AppState } from "react-native";
+import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
 
 const Tab = createBottomTabNavigator<TabNavigatorInterface>();
 
 export const TabNavigator = () => {
+  const [appState, setAppState] = useState(AppState.currentState);
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (appState.match(/inactive|background/) && nextAppState === "active") {
+        console.log("App has come to the foreground!");
+        console.log("isStarted:", IdentityAgentManager.isStarted);
+        // Place your code here that you want to run when the component is displayed in the foreground
+      }
+      setAppState(nextAppState);
+    };
+
+    const subscription = AppState.addEventListener(
+      "change",
+      handleAppStateChange
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [appState]);
+
   return (
     <Tab.Navigator screenOptions={tabOptions}>
       <Tab.Screen

--- a/src/pages/default/connections/ConnectionRequest.tsx
+++ b/src/pages/default/connections/ConnectionRequest.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { SafeAreaView, Text } from "react-native";
+
+const ConnectionRequestScreen = () => {
+  return (
+    <SafeAreaView>
+      <Text>Hello, ConnectionRequestScreen!</Text>
+    </SafeAreaView>
+  );
+};
+
+export default ConnectionRequestScreen;

--- a/src/pages/default/passphrase/EnterPassphrase.tsx
+++ b/src/pages/default/passphrase/EnterPassphrase.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { AppNavigatorProps } from "@/types/navigation";
 import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
+import { Deeplink } from "@/features/deeplink/deeplink";
 
 type Props = AppNavigatorProps<"EnterPassphraseScreen">;
 
@@ -18,6 +19,7 @@ const EnterPassphraseScreen = ({ navigation }: Props) => {
     try {
       await IdentityAgentManager.startAgent(passphrase);
       navigation.replace("Tabs", { screen: "DiscoverScreen" });
+      await Deeplink.openDelayedDeeplinkIfNeeded();
     } catch (e) {
       console.error("Error logging in:", e);
       Alert.alert(

--- a/src/pages/onboarding/create/CreateWallet.tsx
+++ b/src/pages/onboarding/create/CreateWallet.tsx
@@ -5,6 +5,7 @@ import { Typography } from "@/theme/typography";
 import { AppNavigatorProps } from "@/types/navigation";
 import { IdentityAgentManager } from "@/features/identity/IdentityAgentManager";
 import { defaultIdentities } from "@/pages/onboarding/create/default_identities";
+import { Deeplink } from "@/features/deeplink/deeplink";
 
 type Props = AppNavigatorProps<"CreateWalletScreen">;
 
@@ -24,6 +25,7 @@ const CreateWalletScreen = ({ navigation, route }: Props) => {
         );
         await Promise.all(defaultIdentityCreatePromises);
         navigation.replace("Tabs", { screen: "DiscoverScreen" });
+        await Deeplink.openDelayedDeeplinkIfNeeded();
       } catch (e) {
         console.error(e);
       }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -30,6 +30,7 @@ export type AppNavigatorInterface = {
     iconName: keyof typeof Octicons.glyphMap;
   };
   ReviewConnectionScreen: undefined;
+  ConnectionRequestScreen: undefined;
 };
 
 export type TabNavigatorInterface = {


### PR DESCRIPTION
Closes https://github.com/TBD54566975/web5-wallet/issues/87
Closes https://github.com/TBD54566975/web5-wallet/issues/116

When the user launches a deeplink that opens the Web5 Wallet, the wallet must be "unlocked" with the user's passphrase first. Unlocking the wallet must be done, as we cannot read from the DWN unless it has been unlocked. 

This PR delays the handling of deeplinks until the user has successfully unlocked the wallet.

## Demo Videos

In this first video, the user launched a deeplink into the Web5 wallet app, while the app is unlocked in the background. The deeplink can be handled immediately.

[deeplink-app-unlocked.webm](https://github.com/TBD54566975/web5-wallet/assets/88001738/e10a0ba1-7de0-4a6c-ad95-66361a1a307c)

In this next video, the user launches a deeplink, but hasn't unlocked the Web5 Wallet app yet. In this case, the user must first unlock the application. After unlocked, the deeplink can be handled.

[deeplink-not-unlocked.webm](https://github.com/TBD54566975/web5-wallet/assets/88001738/6d8130b6-5b9d-4888-9d53-47d4bd25ae4a)

In this final video, the user launches a deeplink, but hasn't completed onboarding into the Web5 Wallet app yet. In this case, the user must first complete onboarding. After completing onboarding, the deeplink can be handled.

[deeplink-onboarding.webm](https://github.com/TBD54566975/web5-wallet/assets/88001738/499b52e9-c70d-460c-b844-65509001a7e9)
