### PR TITLE
Fix scrollViews cutting content off

### DIFF
--- a/src/pages/default/MenuPageLayout.tsx
+++ b/src/pages/default/MenuPageLayout.tsx
@@ -1,6 +1,6 @@
 import { Item, ItemProps } from "@/components/Item";
 import { ColorTheme } from "@/theme/colors";
-import { Layouts } from "@/theme/layouts";
+import { FlexLayouts, Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
 import React from "react";
 import {
@@ -21,8 +21,8 @@ export const MenuPageLayout = (props: {
   const { headerItem, menuTabs, children } = props;
 
   return (
-    <SafeAreaView>
-      <View style={Layouts.container}>
+    <SafeAreaView style={FlexLayouts.wrapper}>
+      <View style={[Layouts.container, FlexLayouts.wrapper]}>
         <View style={Layouts.row}>
           <Item {...headerItem} headingSize="heading3" />
         </View>
@@ -51,7 +51,7 @@ const MenuTab = (props: MenuProps) => {
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 240,
+    flex: 1,
   },
   menu: {
     flexDirection: "row",

--- a/src/pages/default/credentials/AddCredentials.tsx
+++ b/src/pages/default/credentials/AddCredentials.tsx
@@ -1,4 +1,4 @@
-import { Layouts } from "@/theme/layouts";
+import { FlexLayouts, Layouts } from "@/theme/layouts";
 import { Typography } from "@/theme/typography";
 import { For } from "@legendapp/state/react";
 import React from "react";
@@ -16,8 +16,8 @@ const AddCredentialsScreen = ({ navigation }: Props) => {
   };
 
   return (
-    <SafeAreaView>
-      <View style={Layouts.container}>
+    <SafeAreaView style={FlexLayouts.wrapper}>
+      <View style={[Layouts.container, FlexLayouts.wrapper]}>
         <View style={Layouts.row}>
           <Text style={Typography.heading3}>Get a new credential</Text>
         </View>


### PR DESCRIPTION
Closes https://github.com/TBD54566975/web5-wallet/issues/72

The following screens had flex issues with their scrollViews:
* Profile Details
* Credential Details
* Connection Details
* Add a Credential

This manifested itself in the app in two ways:
1. When the user started scrolling the content, it would get cut off
2. The user could only initiate a scroll by starting the scroll with their finger directly on the content. Starting a scroll with their finger in the whitespace below the content had no effect. 

This was due to the scrollView not properly flexing it's contents to fill the remainder of the screen. This can be seen in the following images, where I explicitly set the background color of the scrollView to magenta:

| Before | After | 
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-09-27 at 09 53 11](https://github.com/TBD54566975/web5-wallet/assets/88001738/d2ed8dc2-4ac7-4b6a-b215-9fee289e4d04) | ![Simulator Screenshot - iPhone 14 Pro - 2023-09-27 at 09 52 30](https://github.com/TBD54566975/web5-wallet/assets/88001738/4c49c7d0-115e-4892-9d3e-19656af7e0a2) |

This PR fixes these flex issues on these screen.

## Video Demos

https://github.com/TBD54566975/web5-wallet/assets/88001738/65677528-37fc-40d2-8c5a-c734c334b708

https://github.com/TBD54566975/web5-wallet/assets/88001738/b4d149ce-2e8d-4805-9f29-4f1d8598f3e6
