### PR TITLE
Wrap CreatePassphraseScreen in KeyboardAvoidingView

### DIFF
--- a/src/pages/onboarding/create/CreatePassphrase.tsx
+++ b/src/pages/onboarding/create/CreatePassphrase.tsx
@@ -5,6 +5,7 @@ import { View, Text, SafeAreaView } from "react-native";
 import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { AppNavigatorProps } from "@/types/navigation";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 
 // Minimum number of characters that are required for a password to be considered valid
 const MIN_PASSPHRASE_LENGTH = 3;
@@ -22,40 +23,42 @@ const CreatePassphraseScreen = ({ navigation }: Props) => {
 
   return (
     <SafeAreaView style={FlexLayouts.wrapper}>
-      <View style={[Layouts.container, FlexLayouts.containerVerticalCenter]}>
-        <View style={Layouts.row}>
-          <Text style={Typography.heading3}>
-            Next up, let&apos;s create your passphrase
-          </Text>
-        </View>
-        <View style={Layouts.row}>
-          <Text style={Typography.paragraph2}>
-            You will use your passphrase to login when you launch the app.
-          </Text>
-          <Text style={Typography.paragraph2}>
-            Make sure it&apos;s memorable, and strong!
-          </Text>
-        </View>
-        <View style={Layouts.row}>
-          <Input
-            label=""
-            nativeID="passphrase"
-            placeholder={"Passphrase"}
-            value={passphrase}
-            onChangeText={setPassphrase}
-            autoComplete="new-password"
-            autoCapitalize="none"
-            autoCorrect={false}
-            clearButtonMode="while-editing"
+      <KeyboardAvoidingView behavior={"padding"} style={FlexLayouts.wrapper}>
+        <View style={[Layouts.container, FlexLayouts.containerVerticalCenter]}>
+          <View style={Layouts.row}>
+            <Text style={Typography.heading3}>
+              Next up, let&apos;s create your passphrase
+            </Text>
+          </View>
+          <View style={Layouts.row}>
+            <Text style={Typography.paragraph2}>
+              You will use your passphrase to login when you launch the app.
+            </Text>
+            <Text style={Typography.paragraph2}>
+              Make sure it&apos;s memorable, and strong!
+            </Text>
+          </View>
+          <View style={Layouts.row}>
+            <Input
+              label=""
+              nativeID="passphrase"
+              placeholder={"Passphrase"}
+              value={passphrase}
+              onChangeText={setPassphrase}
+              autoComplete="new-password"
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+            />
+          </View>
+          <Button
+            kind={isPassphraseValid ? "primary" : "disabled"}
+            text="Next"
+            onPress={nextTapped}
+            disabled={!isPassphraseValid}
           />
         </View>
-        <Button
-          kind={isPassphraseValid ? "primary" : "disabled"}
-          text="Next"
-          onPress={nextTapped}
-          disabled={!isPassphraseValid}
-        />
-      </View>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
Resolves https://github.com/TBD54566975/web5-wallet/issues/71 (should be the final fix here)

Fixes the `CreatePassphraseScreen`, avoiding the keyboard when the user starts editing the text field

| Before | After |
| --- | --- | 
| ![Simulator Screenshot - iPhone 13 mini - 2023-10-03 at 08 56 15](https://github.com/TBD54566975/web5-wallet/assets/88001738/95173ecb-7f21-4fad-a639-dc2446d5c435) | ![Simulator Screenshot - iPhone 13 mini - 2023-10-03 at 08 55 40](https://github.com/TBD54566975/web5-wallet/assets/88001738/ee0bc331-0173-4e66-a2b4-39bfdb4aaad6) |
