### PR TITLE
DWN sync fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@tbd54566975/dwn-sdk-js": "0.2.3",
     "@tbd54566975/web5": "0.7.11",
     "@tbd54566975/web5-react-native-metro-config": "0.1.3",
-    "@tbd54566975/web5-react-native-polyfills": "0.1.3",
+    "@tbd54566975/web5-react-native-polyfills": "0.2.1",
     "@types/uuid": "9.0.4",
     "@web5/api": "0.8.1-alpha-20231003-e73c548",
     "@web5/dids": "0.2.0-alpha-20231003-e73c548",

--- a/src/features/identity/IdentityAgentManager.ts
+++ b/src/features/identity/IdentityAgentManager.ts
@@ -125,6 +125,10 @@ const createIdentity = async (
     },
     store: true,
   });
+
+  // Register the new identity with syncManager so that all records associated
+  // with it (including the profile) get synced to the remote DWN servers.
+  await agent.syncManager.registerIdentity({ did: identity.did });
 };
 
 const listIdentities = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2597,16 +2597,17 @@
   resolved "https://registry.yarnpkg.com/@tbd54566975/web5-react-native-metro-config/-/web5-react-native-metro-config-0.1.3.tgz#d34f516235eed50cc2af6fcb632e0782694e30ad"
   integrity sha512-HgX/YXjAFn4vuwsD1Z087sbGP6zc+NpJ9URogybzm4nPMV811uqI1bBe6lG/ut6zGYfMgAYMpO9MwAIUcd7KqA==
 
-"@tbd54566975/web5-react-native-polyfills@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@tbd54566975/web5-react-native-polyfills/-/web5-react-native-polyfills-0.1.3.tgz#f936ed440929afba74517476995a81f821c4986b"
-  integrity sha512-13XVAcBmyvODck1NuQZ9RwJms3KisQaT76nY8mRxZR3Q+CBTU6iX7e2gMA9QYIiSLcxvIkl7f6sePHzdfn751w==
+"@tbd54566975/web5-react-native-polyfills@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tbd54566975/web5-react-native-polyfills/-/web5-react-native-polyfills-0.2.1.tgz#64f94d67f375241ed3e1b3945f8ee77e68d2f3d3"
+  integrity sha512-RQknKKOJhwtjsuBZgsNthg+gvMexfhvdZmzs99PvxdjegyxqVvyqA2+PPVxYBse8NmtMbjnRqh6Q+AXrC4E77Q==
   dependencies:
     "@azure/core-asynciterator-polyfill" "^1.0.2"
     "@babel/plugin-proposal-private-methods" "^7.18.6"
     "@noble/hashes" "^1.3.1"
     event-target-polyfill "^0.0.3"
     fastestsmallesttextencoderdecoder "^1.0.22"
+    react-native-url-polyfill "^2.0.0"
     stream-browserify "^3.0.0"
 
 "@tbd54566975/web5-user-agent@0.1.10":
@@ -3649,7 +3650,7 @@ buffer@6.0.3, buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buffer@^5.5.0:
+buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -8227,6 +8228,13 @@ react-native-screens@3.22.1:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-url-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"
+  integrity sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
+
 react-native@0.72.3:
   version "0.72.3"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.72.3.tgz#f8d85ec81c9f3592d091ec8e9ac1694956a72765"
@@ -9682,6 +9690,11 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
 webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
@@ -9691,6 +9704,15 @@ whatwg-fetch@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
+  dependencies:
+    buffer "^5.4.3"
+    punycode "^2.1.1"
+    webidl-conversions "^5.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Resolves https://github.com/TBD54566975/web5-wallet/issues/140

Two sync-related changes: 
* Pulls in the latest `@tbd54566975/web5-react-native-polyfills` version, which adds a URL polyfill https://github.com/TBD54566975/web5-react-native-polyfills/pull/2 
    * DWN sync relies on the `URL.prototocol` property, which was previously not implemented.
* After creating a new identity, that identity's DID is registered with the sync manager
    * This fixes the case where a user creates a new identity. The identity's records will now sync immediately, instead of waiting for the next app launch. 